### PR TITLE
지출 목록 조회, 수정, 삭제 API, 예산 목록 조회 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 예산 관리 어플리케이션
 
 ## DB Table
-![샘셈_ERD](https://github.com/dbgusrb12/budget-management-service/assets/65672148/494fbe32-e136-4ba6-b8a1-febf723056cd)
+![샘셈_ERD5](https://github.com/Won-dy/saemsem-backend/assets/65672148/f0eb9fae-be74-4417-a27d-23d1fb50bee4)

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
@@ -28,7 +28,7 @@ public class BudgetController {
 
     @PostMapping
     public Response<Void> createBudget(@Valid @RequestBody CreateBudgetRequest request, @RequestAttribute(name = USER_ID_KEY) String userId) {
-        budgetService.createBudget(request.getDate(), request.getBudgets(), userId);
+        budgetService.createBudget(DateUtils.convertFirstDayOfMonth(request.getDate()), request.getBudgets(), userId);
         return Response.OK;
     }
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
@@ -3,14 +3,20 @@ package com.wealdy.saemsembackend.domain.budget.controller;
 import static com.wealdy.saemsembackend.domain.core.Constant.USER_ID_KEY;
 
 import com.wealdy.saemsembackend.domain.budget.controller.request.CreateBudgetRequest;
+import com.wealdy.saemsembackend.domain.budget.controller.response.BudgetListResponse;
 import com.wealdy.saemsembackend.domain.budget.service.BudgetService;
 import com.wealdy.saemsembackend.domain.core.response.Response;
+import com.wealdy.saemsembackend.domain.core.util.DateUtils;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,5 +30,14 @@ public class BudgetController {
     public Response<Void> createBudget(@Valid @RequestBody CreateBudgetRequest request, @RequestAttribute(name = USER_ID_KEY) String userId) {
         budgetService.createBudget(request.getDate(), request.getBudgets(), userId);
         return Response.OK;
+    }
+
+    @GetMapping
+    public Response<BudgetListResponse> getBudgetList(
+        @RequestParam @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "날짜 형식은 'yyyy-MM' 으로 입력해야 합니다.") String date,
+        @RequestAttribute(name = USER_ID_KEY) String userId
+    ) {
+        LocalDate localDate = DateUtils.convertFirstDayOfMonth(date);
+        return Response.of(BudgetListResponse.of(localDate, budgetService.getBudgetList(localDate, userId)));
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
@@ -8,9 +8,11 @@ import com.wealdy.saemsembackend.domain.budget.service.BudgetService;
 import com.wealdy.saemsembackend.domain.core.response.Response;
 import com.wealdy.saemsembackend.domain.core.util.DateUtils;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -22,22 +24,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/budgets")
+@Validated
 public class BudgetController {
 
     private final BudgetService budgetService;
 
     @PostMapping
     public Response<Void> createBudget(@Valid @RequestBody CreateBudgetRequest request, @RequestAttribute(name = USER_ID_KEY) String userId) {
-        budgetService.createBudget(DateUtils.convertFirstDayOfMonth(request.getDate()), request.getBudgets(), userId);
+        budgetService.createBudget(DateUtils.convertFirstDayOfMonth(request.getYear(), request.getMonth()), request.getBudgets(), userId);
         return Response.OK;
     }
 
     @GetMapping
     public Response<BudgetListResponse> getBudgetList(
-        @RequestParam @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "날짜 형식은 'yyyy-MM' 으로 입력해야 합니다.") String date,
+        @RequestParam @Positive(message = "년도는 0 이상으로 입력해야 합니다.") int year,
+        @RequestParam @Range(min = 1, max = 12, message = "월은 1~12 범위 내에서 입력해야 합니다.") int month,
         @RequestAttribute(name = USER_ID_KEY) String userId
     ) {
-        LocalDate localDate = DateUtils.convertFirstDayOfMonth(date);
+        LocalDate localDate = DateUtils.convertFirstDayOfMonth(year, month);
         return Response.of(BudgetListResponse.of(localDate, budgetService.getBudgetList(localDate, userId)));
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
@@ -5,10 +5,10 @@ import static com.wealdy.saemsembackend.domain.core.Constant.USER_ID_KEY;
 import com.wealdy.saemsembackend.domain.budget.controller.request.CreateBudgetRequest;
 import com.wealdy.saemsembackend.domain.budget.service.BudgetService;
 import com.wealdy.saemsembackend.domain.core.response.Response;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,8 +21,7 @@ public class BudgetController {
     private final BudgetService budgetService;
 
     @PostMapping
-    public Response<Void> createBudget(@Valid @RequestBody CreateBudgetRequest request, HttpServletRequest httpRequest) {
-        String userId = String.valueOf(httpRequest.getAttribute(USER_ID_KEY));
+    public Response<Void> createBudget(@Valid @RequestBody CreateBudgetRequest request, @RequestAttribute(name = USER_ID_KEY) String userId) {
         budgetService.createBudget(request.getDate(), request.getBudgets(), userId);
         return Response.OK;
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/request/CreateBudgetRequest.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/request/CreateBudgetRequest.java
@@ -3,6 +3,7 @@ package com.wealdy.saemsembackend.domain.budget.controller.request;
 import com.wealdy.saemsembackend.domain.budget.service.dto.GetBudgetDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import lombok.Getter;
@@ -13,5 +14,7 @@ public class CreateBudgetRequest {
     @NotBlank(message = "날짜는 필수 값입니다.")
     @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "날짜 형식은 'yyyy-MM' 으로 입력해야 합니다.")
     private String date;
+
+    @NotEmpty(message = "예산은 필수 값입니다.")
     private List<@Valid GetBudgetDto> budgets;
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/request/CreateBudgetRequest.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/request/CreateBudgetRequest.java
@@ -1,6 +1,6 @@
 package com.wealdy.saemsembackend.domain.budget.controller.request;
 
-import com.wealdy.saemsembackend.domain.budget.service.dto.GetBudgetDto;
+import com.wealdy.saemsembackend.domain.budget.service.dto.BudgetSummaryDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
@@ -18,5 +18,5 @@ public class CreateBudgetRequest {
     private int month;
 
     @NotEmpty(message = "예산은 필수 값입니다.")
-    private List<@Valid GetBudgetDto> budgets;
+    private List<@Valid BudgetSummaryDto> budgets;
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/request/CreateBudgetRequest.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/request/CreateBudgetRequest.java
@@ -2,15 +2,16 @@ package com.wealdy.saemsembackend.domain.budget.controller.request;
 
 import com.wealdy.saemsembackend.domain.budget.service.dto.GetBudgetDto;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class CreateBudgetRequest {
 
-    @NotNull(message = "날짜는 필수 값입니다.")
-    private LocalDate date;
+    @NotBlank(message = "날짜는 필수 값입니다.")
+    @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "날짜 형식은 'yyyy-MM' 으로 입력해야 합니다.")
+    private String date;
     private List<@Valid GetBudgetDto> budgets;
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/request/CreateBudgetRequest.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/request/CreateBudgetRequest.java
@@ -2,18 +2,20 @@ package com.wealdy.saemsembackend.domain.budget.controller.request;
 
 import com.wealdy.saemsembackend.domain.budget.service.dto.GetBudgetDto;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.Getter;
+import org.hibernate.validator.constraints.Range;
 
 @Getter
 public class CreateBudgetRequest {
 
-    @NotBlank(message = "날짜는 필수 값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}$", message = "날짜 형식은 'yyyy-MM' 으로 입력해야 합니다.")
-    private String date;
+    @Positive(message = "년도는 양수로 입력해야 합니다.")
+    private int year;
+
+    @Range(min = 1, max = 12, message = "월은 1~12 중 하나로 입력해야 합니다.")
+    private int month;
 
     @NotEmpty(message = "예산은 필수 값입니다.")
     private List<@Valid GetBudgetDto> budgets;

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/response/BudgetListResponse.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/response/BudgetListResponse.java
@@ -11,8 +11,8 @@ import lombok.Getter;
 @Getter
 public class BudgetListResponse {
 
-    private LocalDate date;
-    private List<GetBudgetDto> budgets;
+    private final LocalDate date;
+    private final List<GetBudgetDto> budgets;
 
     public static BudgetListResponse of(LocalDate date, List<GetBudgetDto> budgets) {
         return new BudgetListResponse(date, budgets);

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/response/BudgetListResponse.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/response/BudgetListResponse.java
@@ -1,0 +1,20 @@
+package com.wealdy.saemsembackend.domain.budget.controller.response;
+
+import com.wealdy.saemsembackend.domain.budget.service.dto.GetBudgetDto;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class BudgetListResponse {
+
+    private LocalDate date;
+    private List<GetBudgetDto> budgets;
+
+    public static BudgetListResponse of(LocalDate date, List<GetBudgetDto> budgets) {
+        return new BudgetListResponse(date, budgets);
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/entity/Budget.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/entity/Budget.java
@@ -29,7 +29,7 @@ public class Budget {
     private LocalDate date;  // 예산의 기준 날짜
 
     @Column(nullable = false)
-    private int amount;  // 금액
+    private long amount;  // 금액
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -39,19 +39,19 @@ public class Budget {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;  // 카테고리
 
-    private Budget(LocalDate date, int amount, User user, Category category) {
+    private Budget(LocalDate date, long amount, User user, Category category) {
         this.date = date;
         this.amount = amount;
         this.user = user;
         this.category = category;
     }
 
-    public void updateBudget(int amount) {
+    public void updateBudget(long amount) {
         this.amount = amount;
     }
 
     // 생성 메서드
-    public static Budget createBudget(LocalDate date, int amount, User user, Category category) {
+    public static Budget createBudget(LocalDate date, long amount, User user, Category category) {
         return new Budget(
             date,
             amount,

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/BudgetRepository.java
@@ -4,9 +4,10 @@ import com.wealdy.saemsembackend.domain.budget.entity.Budget;
 import com.wealdy.saemsembackend.domain.category.entity.Category;
 import com.wealdy.saemsembackend.domain.user.entity.User;
 import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
 
-    Budget findByDateAndCategoryAndUser(LocalDate date, Category category, User user);
+    Optional<Budget> findByDateAndCategoryAndUser(LocalDate date, Category category, User user);
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/BudgetRepository.java
@@ -1,13 +1,21 @@
 package com.wealdy.saemsembackend.domain.budget.repository;
 
 import com.wealdy.saemsembackend.domain.budget.entity.Budget;
+import com.wealdy.saemsembackend.domain.budget.repository.projection.BudgetSummaryProjection;
 import com.wealdy.saemsembackend.domain.category.entity.Category;
 import com.wealdy.saemsembackend.domain.user.entity.User;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
 
     Optional<Budget> findByDateAndCategoryAndUser(LocalDate date, Category category, User user);
+
+    @Query(value = "select c.name as categoryName, coalesce(b.amount, 0) as amount from Category c "
+        + "left join Budget b on c.id = b.category.id and b.date = :date and b.user = :user")
+    List<BudgetSummaryProjection> findByDateAndUser(@Param("date") LocalDate date, @Param("user") User user);
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/projection/BudgetSummaryProjection.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/projection/BudgetSummaryProjection.java
@@ -1,0 +1,7 @@
+package com.wealdy.saemsembackend.domain.budget.repository.projection;
+
+public interface BudgetSummaryProjection {
+
+    String getCategoryName();
+    Long getAmount();
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -1,5 +1,6 @@
 package com.wealdy.saemsembackend.domain.budget.service;
 
+import com.wealdy.saemsembackend.domain.budget.service.dto.BudgetSummaryDto;
 import com.wealdy.saemsembackend.domain.budget.entity.Budget;
 import com.wealdy.saemsembackend.domain.budget.repository.BudgetRepository;
 import com.wealdy.saemsembackend.domain.budget.service.dto.GetBudgetDto;
@@ -23,7 +24,7 @@ public class BudgetService {
     private final UserService userService;
 
     @Transactional
-    public void createBudget(LocalDate date, List<GetBudgetDto> getBudgetDtoList, String userId) {
+    public void createBudget(LocalDate date, List<BudgetSummaryDto> getBudgetDtoList, String userId) {
         getBudgetDtoList
             .forEach(getBudgetDto -> {
                 User user = userService.getUserById(userId);

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -44,6 +44,7 @@ public class BudgetService {
             });
     }
 
+    @Transactional(readOnly = true)
     public List<GetBudgetDto> getBudgetList(LocalDate date, String userId) {
         User user = userService.getUserById(userId);
         return budgetRepository.findByDateAndUser(date, user).stream()

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -44,10 +44,9 @@ public class BudgetService {
     }
 
     public List<GetBudgetDto> getBudgetList(LocalDate date, String userId) {
-        // todo: Budget 의 amount int -> long 으로 바꿀 예정
         User user = userService.getUserById(userId);
         return budgetRepository.findByDateAndUser(date, user).stream()
-            .map(projection -> GetBudgetDto.of(projection.getCategoryName(), projection.getAmount().intValue()))
+            .map(projection -> GetBudgetDto.of(projection.getCategoryName(), projection.getAmount()))
             .toList();
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -42,4 +42,12 @@ public class BudgetService {
                 }
             });
     }
+
+    public List<GetBudgetDto> getBudgetList(LocalDate date, String userId) {
+        // todo: Budget 의 amount int -> long 으로 바꿀 예정
+        User user = userService.getUserById(userId);
+        return budgetRepository.findByDateAndUser(date, user).stream()
+            .map(projection -> GetBudgetDto.of(projection.getCategoryName(), projection.getAmount().intValue()))
+            .toList();
+    }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -27,7 +27,7 @@ public class BudgetService {
             .forEach(getBudgetDto -> {
                 User user = userRepository.findById(userId).get(0);
                 Category category = categoryService.findByName(getBudgetDto.getCategoryName());
-                Budget findBudget = findByDateAndCategoryAndUser(date, category, user);
+                Budget findBudget = budgetRepository.findByDateAndCategoryAndUser(date, category, user);
                 if (findBudget == null) {
                     Budget budget = Budget.createBudget(
                         date,
@@ -40,9 +40,5 @@ public class BudgetService {
                     findBudget.updateBudget(getBudgetDto.getAmount());
                 }
             });
-    }
-
-    private Budget findByDateAndCategoryAndUser(LocalDate date, Category category, User user) {
-        return budgetRepository.findByDateAndCategoryAndUser(date, category, user);
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -29,17 +29,18 @@ public class BudgetService {
                 User user = userService.getUserById(userId);
                 Category category = categoryService.getCategory(getBudgetDto.getCategoryName());
                 Optional<Budget> findBudget = budgetRepository.findByDateAndCategoryAndUser(date, category, user);
-                if (findBudget.isEmpty()) {
-                    Budget budget = Budget.createBudget(
-                        date,
-                        getBudgetDto.getAmount(),
-                        user,
-                        category
-                    );
-                    budgetRepository.save(budget);
-                } else {
-                    findBudget.get().updateBudget(getBudgetDto.getAmount());
-                }
+                findBudget.ifPresentOrElse(
+                    budget -> budget.updateBudget(getBudgetDto.getAmount()),
+                    () -> {
+                        Budget budget = Budget.createBudget(
+                            date,
+                            getBudgetDto.getAmount(),
+                            user,
+                            category
+                        );
+                        budgetRepository.save(budget);
+                    }
+                );
             });
     }
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -6,7 +6,7 @@ import com.wealdy.saemsembackend.domain.budget.service.dto.GetBudgetDto;
 import com.wealdy.saemsembackend.domain.category.entity.Category;
 import com.wealdy.saemsembackend.domain.category.service.CategoryService;
 import com.wealdy.saemsembackend.domain.user.entity.User;
-import com.wealdy.saemsembackend.domain.user.repository.UserRepository;
+import com.wealdy.saemsembackend.domain.user.service.UserService;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -20,13 +20,13 @@ public class BudgetService {
 
     private final BudgetRepository budgetRepository;
     private final CategoryService categoryService;
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     @Transactional
     public void createBudget(LocalDate date, List<GetBudgetDto> getBudgetDtoList, String userId) {
         getBudgetDtoList
             .forEach(getBudgetDto -> {
-                User user = userRepository.findById(userId).get(0);
+                User user = userService.getUserById(userId);
                 Category category = categoryService.getCategoryByName(getBudgetDto.getCategoryName());
                 Optional<Budget> findBudget = budgetRepository.findByDateAndCategoryAndUser(date, category, user);
                 if (findBudget.isEmpty()) {

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -9,6 +9,7 @@ import com.wealdy.saemsembackend.domain.user.entity.User;
 import com.wealdy.saemsembackend.domain.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,9 +27,9 @@ public class BudgetService {
         getBudgetDtoList
             .forEach(getBudgetDto -> {
                 User user = userRepository.findById(userId).get(0);
-                Category category = categoryService.findByName(getBudgetDto.getCategoryName());
-                Budget findBudget = budgetRepository.findByDateAndCategoryAndUser(date, category, user);
-                if (findBudget == null) {
+                Category category = categoryService.getCategoryByName(getBudgetDto.getCategoryName());
+                Optional<Budget> findBudget = budgetRepository.findByDateAndCategoryAndUser(date, category, user);
+                if (findBudget.isEmpty()) {
                     Budget budget = Budget.createBudget(
                         date,
                         getBudgetDto.getAmount(),
@@ -37,7 +38,7 @@ public class BudgetService {
                     );
                     budgetRepository.save(budget);
                 } else {
-                    findBudget.updateBudget(getBudgetDto.getAmount());
+                    findBudget.get().updateBudget(getBudgetDto.getAmount());
                 }
             });
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -27,7 +27,7 @@ public class BudgetService {
         getBudgetDtoList
             .forEach(getBudgetDto -> {
                 User user = userService.getUserById(userId);
-                Category category = categoryService.getCategoryByName(getBudgetDto.getCategoryName());
+                Category category = categoryService.getCategory(getBudgetDto.getCategoryName());
                 Optional<Budget> findBudget = budgetRepository.findByDateAndCategoryAndUser(date, category, user);
                 if (findBudget.isEmpty()) {
                     Budget budget = Budget.createBudget(

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/BudgetSummaryDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/BudgetSummaryDto.java
@@ -1,0 +1,15 @@
+package com.wealdy.saemsembackend.domain.budget.service.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+
+@Getter
+public class BudgetSummaryDto {
+
+    @NotBlank(message = "카테고리는 필수 값입니다.")
+    private String categoryName;
+
+    @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.")
+    private long amount;
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/GetBudgetDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/GetBudgetDto.java
@@ -1,7 +1,7 @@
 package com.wealdy.saemsembackend.domain.budget.service.dto;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 
 @Getter
@@ -10,6 +10,6 @@ public class GetBudgetDto {
     @NotBlank(message = "카테고리는 필수 값입니다.")
     private String categoryName;
 
-    @Min(value = 0, message = "금액은 0원 이상으로 입력해야 합니다.")
+    @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.")
     private int amount;
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/GetBudgetDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/GetBudgetDto.java
@@ -11,10 +11,10 @@ import lombok.Getter;
 public class GetBudgetDto {
 
     @NotBlank(message = "카테고리는 필수 값입니다.")
-    private String categoryName;
+    private final String categoryName;
 
     @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.")
-    private long amount;
+    private final long amount;
 
     public static GetBudgetDto of(String categoryName, long amount) {
         return new GetBudgetDto(categoryName, amount);

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/GetBudgetDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/GetBudgetDto.java
@@ -14,9 +14,9 @@ public class GetBudgetDto {
     private String categoryName;
 
     @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.")
-    private int amount;
+    private long amount;
 
-    public static GetBudgetDto of(String categoryName, int amount) {
+    public static GetBudgetDto of(String categoryName, long amount) {
         return new GetBudgetDto(categoryName, amount);
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/GetBudgetDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/GetBudgetDto.java
@@ -2,8 +2,11 @@ package com.wealdy.saemsembackend.domain.budget.service.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class GetBudgetDto {
 
@@ -12,4 +15,8 @@ public class GetBudgetDto {
 
     @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.")
     private int amount;
+
+    public static GetBudgetDto of(String categoryName, int amount) {
+        return new GetBudgetDto(categoryName, amount);
+    }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/controller/CategoryController.java
@@ -2,7 +2,6 @@ package com.wealdy.saemsembackend.domain.category.controller;
 
 import com.wealdy.saemsembackend.domain.category.controller.response.CategoryListResponse;
 import com.wealdy.saemsembackend.domain.category.service.CategoryService;
-import com.wealdy.saemsembackend.domain.core.response.ListResponseDto;
 import com.wealdy.saemsembackend.domain.core.response.Response;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +20,11 @@ public class CategoryController {
      * 카테고리 목록 조회 API
      */
     @GetMapping
-    public Response<ListResponseDto<CategoryListResponse>> getCategoryList() {
+    public Response<List<CategoryListResponse>> getCategoryList() {
         List<CategoryListResponse> categories = categoryService.getCategoryList().stream()
             .map(CategoryListResponse::from)
             .toList();
 
-        return Response.of(ListResponseDto.from(categories));
+        return Response.of(categories);
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/controller/CategoryController.java
@@ -5,7 +5,6 @@ import com.wealdy.saemsembackend.domain.category.service.CategoryService;
 import com.wealdy.saemsembackend.domain.core.response.ListResponseDto;
 import com.wealdy.saemsembackend.domain.core.response.Response;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,7 +22,7 @@ public class CategoryController {
     public Response<ListResponseDto<CategoryListResponse>> getCategories() {
         List<CategoryListResponse> categories = categoryService.getCategories().stream()
             .map(CategoryListResponse::from)
-            .collect(Collectors.toList());
+            .toList();
 
         return Response.of(ListResponseDto.from(categories));
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/controller/CategoryController.java
@@ -7,10 +7,12 @@ import com.wealdy.saemsembackend.domain.core.response.Response;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/categories")
 public class CategoryController {
 
     private final CategoryService categoryService;
@@ -18,9 +20,9 @@ public class CategoryController {
     /**
      * 카테고리 목록 조회 API
      */
-    @GetMapping("/category")
-    public Response<ListResponseDto<CategoryListResponse>> getCategories() {
-        List<CategoryListResponse> categories = categoryService.getCategories().stream()
+    @GetMapping
+    public Response<ListResponseDto<CategoryListResponse>> getCategoryList() {
+        List<CategoryListResponse> categories = categoryService.getCategoryList().stream()
             .map(CategoryListResponse::from)
             .toList();
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/controller/response/CategoryListResponse.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/controller/response/CategoryListResponse.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CategoryListResponse {
 
-    private Long id;
-    private String name;
+    private final Long id;
+    private final String name;
 
     public static CategoryListResponse from(GetCategoryDto category) {
         return new CategoryListResponse(category.getId(), category.getName());

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/entity/Category.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/entity/Category.java
@@ -5,15 +5,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 
 @Getter
 @Entity
-@Table(uniqueConstraints = {
-    @UniqueConstraint(name = "unique_category_name", columnNames = {"name"})
-})
 public class Category {
 
     @Id
@@ -21,6 +16,6 @@ public class Category {
     @Column(name = "category_id")
     private Long id;  // 카테고리 id
 
-    @Column(length = 30, nullable = false)
+    @Column(length = 30, nullable = false, unique = true)
     private String name;  // 카테고리명
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/repository/CategoryRepository.java
@@ -1,12 +1,8 @@
 package com.wealdy.saemsembackend.domain.category.repository;
 
-import static com.wealdy.saemsembackend.domain.core.response.ResponseCode.NOT_FOUND_CATEGORY;
-
 import com.wealdy.saemsembackend.domain.category.entity.Category;
-import com.wealdy.saemsembackend.domain.core.exception.NotFoundException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
-import jakarta.persistence.TypedQuery;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -25,19 +21,9 @@ public class CategoryRepository {
         return em.createQuery("select c from Category c", Category.class).getResultList();
     }
 
-    public Category findByName(String name) {
-        // TODO: NoResultException 이 orElseThrow 까지 안오고 getSingleResult() 에서 에러 발생
-//        return Optional.ofNullable(em.createQuery("select c from Category c where c.name=:name", Category.class)
-//            .setParameter("name", name)
-//            .getSingleResult()).orElseThrow(() -> new NotFoundException(NOT_FOUND_CATEGORY));
-
-        TypedQuery<Category> query = em.createQuery("select c from Category c where c.name=:name", Category.class)
-            .setParameter("name", name);
-
-        try {
-            return query.getSingleResult();
-        } catch (NoResultException e) {
-            throw new NotFoundException(NOT_FOUND_CATEGORY);
-        }
+    public Category getCategoryByName(String name) throws NoResultException {
+        return em.createQuery("select c from Category c where c.name=:name", Category.class)
+            .setParameter("name", name)
+            .getSingleResult();
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/repository/CategoryRepository.java
@@ -3,7 +3,9 @@ package com.wealdy.saemsembackend.domain.category.repository;
 import com.wealdy.saemsembackend.domain.category.entity.Category;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -21,9 +23,13 @@ public class CategoryRepository {
         return em.createQuery("select c from Category c", Category.class).getResultList();
     }
 
-    public Category getCategoryByName(String name) throws NoResultException {
-        return em.createQuery("select c from Category c where c.name=:name", Category.class)
-            .setParameter("name", name)
-            .getSingleResult();
+    public Optional<Category> findByName(String name) {
+        TypedQuery<Category> query = em.createQuery("select c from Category c where c.name=:name", Category.class)
+            .setParameter("name", name);
+        try {
+            return Optional.ofNullable(query.getSingleResult());
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/service/CategoryService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/service/CategoryService.java
@@ -6,7 +6,6 @@ import com.wealdy.saemsembackend.domain.category.entity.Category;
 import com.wealdy.saemsembackend.domain.category.repository.CategoryRepository;
 import com.wealdy.saemsembackend.domain.category.service.dto.GetCategoryDto;
 import com.wealdy.saemsembackend.domain.core.exception.NotFoundException;
-import jakarta.persistence.NoResultException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -33,10 +32,7 @@ public class CategoryService {
      * 카테고리 단일 조회 with name
      */
     public Category getCategoryByName(String name) {
-        try {
-            return categoryRepository.getCategoryByName(name);
-        } catch (NoResultException e) {
-            throw new NotFoundException(NOT_FOUND_CATEGORY);
-        }
+        return categoryRepository.findByName(name)
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_CATEGORY));
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/service/CategoryService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/service/CategoryService.java
@@ -1,8 +1,12 @@
 package com.wealdy.saemsembackend.domain.category.service;
 
+import static com.wealdy.saemsembackend.domain.core.response.ResponseCode.NOT_FOUND_CATEGORY;
+
 import com.wealdy.saemsembackend.domain.category.entity.Category;
 import com.wealdy.saemsembackend.domain.category.repository.CategoryRepository;
 import com.wealdy.saemsembackend.domain.category.service.dto.GetCategoryDto;
+import com.wealdy.saemsembackend.domain.core.exception.NotFoundException;
+import jakarta.persistence.NoResultException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +32,11 @@ public class CategoryService {
     /**
      * 카테고리 단일 조회 with name
      */
-    public Category findByName(String name) {
-        return categoryRepository.findByName(name);
+    public Category getCategoryByName(String name) {
+        try {
+            return categoryRepository.getCategoryByName(name);
+        } catch (NoResultException e) {
+            throw new NotFoundException(NOT_FOUND_CATEGORY);
+        }
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/service/CategoryService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/service/CategoryService.java
@@ -7,7 +7,6 @@ import com.wealdy.saemsembackend.domain.category.repository.CategoryRepository;
 import com.wealdy.saemsembackend.domain.category.service.dto.GetCategoryDto;
 import com.wealdy.saemsembackend.domain.core.exception.NotFoundException;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +24,7 @@ public class CategoryService {
     public List<GetCategoryDto> getCategories() {
         return categoryRepository.findAll().stream()
             .map(GetCategoryDto::from)
-            .collect(Collectors.toList());
+            .toList();
     }
 
     /**

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/service/CategoryService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/service/CategoryService.java
@@ -21,7 +21,7 @@ public class CategoryService {
     /**
      * 카테고리 전체 목록 조회
      */
-    public List<GetCategoryDto> getCategories() {
+    public List<GetCategoryDto> getCategoryList() {
         return categoryRepository.findAll().stream()
             .map(GetCategoryDto::from)
             .toList();
@@ -30,7 +30,7 @@ public class CategoryService {
     /**
      * 카테고리 단일 조회 with name
      */
-    public Category getCategoryByName(String name) {
+    public Category getCategory(String name) {
         return categoryRepository.findByName(name)
             .orElseThrow(() -> new NotFoundException(NOT_FOUND_CATEGORY));
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/service/dto/GetCategoryDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/service/dto/GetCategoryDto.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class GetCategoryDto {
 
-    private Long id;
-    private String name;
+    private final Long id;
+    private final String name;
 
     public static GetCategoryDto from(Category category) {
         return new GetCategoryDto(category.getId(), category.getName());

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/dto/auth/JWTDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/dto/auth/JWTDto.java
@@ -1,15 +1,20 @@
 package com.wealdy.saemsembackend.domain.core.dto.auth;
 
 import java.util.Date;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class JWTDto {
 
-    private long userId;
-    private Date expirationTime;
-    private Date createdTime;
-    private String token;
+    private final long userId;
+    private final Date expirationTime;
+    private final Date createdTime;
+    private final String token;
+
+    public static JWTDto of(long userId, Date expirationTime, Date createdTime, String token) {
+        return new JWTDto(userId, expirationTime, createdTime, token);
+    }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/enums/YnColumn.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/enums/YnColumn.java
@@ -13,7 +13,7 @@ public enum YnColumn {
         this.ynBoolean = ynBoolean;
     }
 
-    public static YnColumn fromBoolean(boolean ynBoolean) {
+    public static YnColumn from(boolean ynBoolean) {
         return ynBoolean ? Y : N;
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/exception/ExceptionControllerAdvice.java
@@ -4,38 +4,33 @@ import com.wealdy.saemsembackend.domain.core.response.ErrorResponseDto;
 import com.wealdy.saemsembackend.domain.core.response.ResponseCode;
 import com.wealdy.saemsembackend.domain.core.util.LogUtils;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import java.util.List;
-import org.springframework.context.MessageSourceResolvable;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 @RestControllerAdvice
 public class ExceptionControllerAdvice {
 
     @ExceptionHandler({
         MethodArgumentNotValidException.class,
-        HandlerMethodValidationException.class
+        ConstraintViolationException.class,
     })
     public ErrorResponseDto invalidParameterExceptionHandler(HttpServletRequest request, Exception exception) {
         String errorMessage = "";
-        if (exception instanceof MethodArgumentNotValidException manve) {
-            List<FieldError> fieldErrors = manve.getBindingResult().getFieldErrors();
+        if (exception instanceof MethodArgumentNotValidException methodArgumentNotValidException) {
+            List<FieldError> fieldErrors = methodArgumentNotValidException.getBindingResult().getFieldErrors();
             for (FieldError fieldError : fieldErrors) {
                 System.out.println("[ExceptionControllerAdvice#invalidParameterExceptionHandler] fieldError = " + fieldError);
             }
             errorMessage = fieldErrors.get(0).getDefaultMessage();
-        } else if (exception instanceof HandlerMethodValidationException hmve) {
-
-            List<? extends MessageSourceResolvable> allErrors = hmve.getAllErrors();
-
-            for (int i = 0; i < allErrors.size(); i++) {
-                System.out.println("[ExceptionControllerAdvice#invalidParameterExceptionHandler] parameterError = " + allErrors.get(i));
-                if (i == 0) {
-                    errorMessage = allErrors.get(i).getDefaultMessage();
-                }
+        } else if (exception instanceof ConstraintViolationException constraintViolationException) {
+            for (ConstraintViolation<?> constraintViolation : constraintViolationException.getConstraintViolations()) {
+                System.out.println("[ExceptionControllerAdvice#invalidParameterExceptionHandler] constraintViolation = " + constraintViolation);
+                errorMessage = constraintViolation.getMessage();
             }
         }
         LogUtils.errorLog(request, exception);

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/exception/ExceptionControllerAdvice.java
@@ -5,24 +5,41 @@ import com.wealdy.saemsembackend.domain.core.response.ResponseCode;
 import com.wealdy.saemsembackend.domain.core.util.LogUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
+import org.springframework.context.MessageSourceResolvable;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 @RestControllerAdvice
 public class ExceptionControllerAdvice {
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ErrorResponseDto invalidParameterExceptionHandler(HttpServletRequest request, MethodArgumentNotValidException exception) {
-        List<FieldError> fieldErrors = exception.getBindingResult().getFieldErrors();
-        for (FieldError fieldError : fieldErrors) {
-            System.out.println("fieldError.toString() = " + fieldError.toString());
-        }
+    @ExceptionHandler({
+        MethodArgumentNotValidException.class,
+        HandlerMethodValidationException.class
+    })
+    public ErrorResponseDto invalidParameterExceptionHandler(HttpServletRequest request, Exception exception) {
+        String errorMessage = "";
+        if (exception instanceof MethodArgumentNotValidException manve) {
+            List<FieldError> fieldErrors = manve.getBindingResult().getFieldErrors();
+            for (FieldError fieldError : fieldErrors) {
+                System.out.println("[ExceptionControllerAdvice#invalidParameterExceptionHandler] fieldError = " + fieldError);
+            }
+            errorMessage = fieldErrors.get(0).getDefaultMessage();
+        } else if (exception instanceof HandlerMethodValidationException hmve) {
 
+            List<? extends MessageSourceResolvable> allErrors = hmve.getAllErrors();
+
+            for (int i = 0; i < allErrors.size(); i++) {
+                System.out.println("[ExceptionControllerAdvice#invalidParameterExceptionHandler] parameterError = " + allErrors.get(i));
+                if (i == 0) {
+                    errorMessage = allErrors.get(i).getDefaultMessage();
+                }
+            }
+        }
         LogUtils.errorLog(request, exception);
-        return new ErrorResponseDto(
-            ResponseCode.BAD_REQUEST.getCode(), ResponseCode.INVALID_PARAMETER.getCode(), fieldErrors.get(0).getDefaultMessage());
+        return new ErrorResponseDto(ResponseCode.BAD_REQUEST.getCode(), ResponseCode.INVALID_PARAMETER.getCode(), errorMessage);
     }
 
     @ExceptionHandler(ExceptionBase.class)

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/exception/ExceptionControllerAdvice.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import java.util.List;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,7 +35,7 @@ public class ExceptionControllerAdvice {
             }
         }
         LogUtils.errorLog(request, exception);
-        return new ErrorResponseDto(ResponseCode.BAD_REQUEST.getCode(), ResponseCode.INVALID_PARAMETER.getCode(), errorMessage);
+        return new ErrorResponseDto(HttpStatus.BAD_REQUEST.value(), ResponseCode.INVALID_PARAMETER.getCode(), errorMessage);
     }
 
     @ExceptionHandler(ExceptionBase.class)

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/interceptor/AuthInterceptor.java
@@ -17,6 +17,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @Component
 public class AuthInterceptor implements HandlerInterceptor {
 
+    private final static String PREFIX_BEARER = "Bearer ";
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         LogUtils.accessLog(request, "AuthInterceptor#preHandle");
@@ -25,8 +27,9 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        JwtUtil jwtUtil = new JwtUtil();
-        JWTDto jwt = jwtUtil.parseToken(getTokenFromHeader(request));
+        JwtUtil jwtUtil = JwtUtil.getInstance();
+        String token = removePrefix(getTokenFromHeader(request));
+        JWTDto jwt = jwtUtil.parseToken(token);
         request.setAttribute(USER_ID_KEY, jwt.getUserId());
 
         return true;
@@ -40,5 +43,12 @@ public class AuthInterceptor implements HandlerInterceptor {
         }
 
         throw new InvalidTokenException();
+    }
+
+    private String removePrefix(String token) {
+        if (token.startsWith(PREFIX_BEARER)) {
+            return token.substring(7);
+        }
+        return token;
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/response/ErrorResponseDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/response/ErrorResponseDto.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 @Getter
 public class ErrorResponseDto {
 
-    private boolean error;
-    private int httpStatusCode;
-    private int errorCode;
-    private String errorMessage;
+    private final boolean error;
+    private final int httpStatusCode;
+    private final int errorCode;
+    private final String errorMessage;
 
     public ErrorResponseDto(ExceptionBase exception) {
         this.error = true;

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/response/IdResponseDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/response/IdResponseDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class IdResponseDto {
 
-    private long id;
+    private final long id;
 
     public static IdResponseDto from(long id) {
         return new IdResponseDto(id);

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/response/ListResponseDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/response/ListResponseDto.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ListResponseDto<T> {
 
-    private long total;
-    private List<T> list;
+    private final long total;
+    private final List<T> list;
 
     public static <T> ListResponseDto<T> of(long total, List<T> list) {
         return new ListResponseDto<>(total, list);

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/response/Response.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/response/Response.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 public class Response<T> {
 
     public static final Response<Void> OK = new Response<>();
-//    public static final Response<Void> OK2 = Response.of(null);
 
     private final boolean success = true;
     private final int code = ResponseCode.SUCCESS.getCode();

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/response/Response.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/response/Response.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class Response<T> {
 
     public static final Response<Void> OK = new Response<>();
+//    public static final Response<Void> OK2 = Response.of(null);
 
     private final boolean success = true;
     private final int code = ResponseCode.SUCCESS.getCode();

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/util/DateUtils.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/util/DateUtils.java
@@ -1,0 +1,10 @@
+package com.wealdy.saemsembackend.domain.core.util;
+
+import java.time.LocalDate;
+
+public class DateUtils {
+
+    public static LocalDate convertFirstDayOfMonth(String date) {
+        return LocalDate.parse(date + "-01");
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/util/DateUtils.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/util/DateUtils.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 
 public class DateUtils {
 
-    public static LocalDate convertFirstDayOfMonth(String date) {
-        return LocalDate.parse(date + "-01");
+    public static LocalDate convertFirstDayOfMonth(int year, int month) {
+        return LocalDate.of(year, month, 1);
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/util/JwtUtil.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/util/JwtUtil.java
@@ -13,11 +13,22 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.util.Date;
 import javax.crypto.SecretKey;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JwtUtil {
 
+    private static class JwtUtilProvider {
+
+        private static final JwtUtil INSTANCE = new JwtUtil();
+    }
+
+    public static JwtUtil getInstance() {
+        return JwtUtilProvider.INSTANCE;
+    }
+
     private final static String secret = "djtyS5dopy5dfNt9dfgPmwch5d6klsg0sdlk1kYDgp";
-    private final static String PREFIX_BEARER = "Bearer ";
     private final static int ACCESS_TOKEN_EXPIRATION = 86400;  // 1 DAY
 
     public String createAccessToken(long userId) {
@@ -34,8 +45,7 @@ public class JwtUtil {
             .compact();
     }
 
-    public JWTDto parseToken(String tokenString) {
-        String token = removePrefix(tokenString);
+    public JWTDto parseToken(String token) {
         SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
 
         try {
@@ -50,12 +60,5 @@ public class JwtUtil {
         } catch (JwtException ex) {
             throw new InvalidTokenException();
         }
-    }
-
-    private String removePrefix(String token) {
-        if (token.startsWith(PREFIX_BEARER)) {
-            return token.substring(7);
-        }
-        return token;
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/util/JwtUtil.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/util/JwtUtil.java
@@ -12,6 +12,7 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.util.Date;
+import java.util.Objects;
 import javax.crypto.SecretKey;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -19,13 +20,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JwtUtil {
 
-    private static class JwtUtilProvider {
-
-        private static final JwtUtil INSTANCE = new JwtUtil();
-    }
+    private static JwtUtil instance;
 
     public static JwtUtil getInstance() {
-        return JwtUtilProvider.INSTANCE;
+        if (Objects.isNull(instance)) {
+            instance = new JwtUtil();
+        }
+        return instance;
     }
 
     private final static String secret = "djtyS5dopy5dfNt9dfgPmwch5d6klsg0sdlk1kYDgp";

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/util/JwtUtil.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/util/JwtUtil.java
@@ -44,7 +44,7 @@ public class JwtUtil {
                 .build().parseSignedClaims(token);
             Claims claims = claimsJws.getPayload();
 
-            return new JWTDto(claims.get(USER_ID_KEY, Long.class), claims.getExpiration(), claims.getIssuedAt(), token);
+            return JWTDto.of(claims.get(USER_ID_KEY, Long.class), claims.getExpiration(), claims.getIssuedAt(), token);
         } catch (ExpiredJwtException ex) {
             throw new ExpiredTokenException();
         } catch (JwtException ex) {

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -3,12 +3,17 @@ package com.wealdy.saemsembackend.domain.spending.controller;
 import static com.wealdy.saemsembackend.domain.core.Constant.USER_ID_KEY;
 
 import com.wealdy.saemsembackend.domain.core.response.IdResponseDto;
+import com.wealdy.saemsembackend.domain.core.response.ListResponseDto;
 import com.wealdy.saemsembackend.domain.core.response.Response;
+import com.wealdy.saemsembackend.domain.spending.controller.dto.SpendingSummaryDto;
 import com.wealdy.saemsembackend.domain.spending.controller.request.CreateSpendingRequest;
+import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingListResponse;
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingResponse;
 import com.wealdy.saemsembackend.domain.spending.service.SpendingService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,6 +43,26 @@ public class SpendingController {
     @GetMapping("/{spendingId}")
     public Response<SpendingResponse> getSpending(@PathVariable Long spendingId) {
         return Response.of(SpendingResponse.from(spendingService.getSpending(spendingId)));
+    }
+
+    @GetMapping
+    public Response<SpendingListResponse> getSpendingList(
+        @RequestParam LocalDate startDate,
+        @RequestParam LocalDate endDate,
+        @RequestParam(required = false) List<String> category,
+        @RequestParam(required = false) Long minAmount,
+        @RequestParam(required = false) Long maxAmount
+    ) {
+        ListResponseDto<SpendingResponse> spendingList = ListResponseDto.from(
+            spendingService.getSpendingList(startDate, endDate, category, minAmount, maxAmount).stream()
+                .map(SpendingResponse::from)
+                .toList());
+        long sumOfAmount = spendingService.getSumOfAmountByDate(startDate, endDate);
+        List<SpendingSummaryDto> sumOfAmountByCategory = spendingService.getSumOfAmountByCategory(startDate, endDate).stream()
+            .map(SpendingSummaryDto::from)
+            .toList();
+
+        return Response.of(SpendingListResponse.of(sumOfAmount, sumOfAmountByCategory, spendingList));
     }
 
     @DeleteMapping("/{spendingId}")

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -36,7 +36,7 @@ public class SpendingController {
     private final SpendingService spendingService;
 
     @PostMapping
-    public Response<IdResponseDto> create(@Valid @RequestBody SaveSpendingRequest request, @RequestAttribute(name = USER_ID_KEY) String userId) {
+    public Response<IdResponseDto> createSpending(@Valid @RequestBody SaveSpendingRequest request, @RequestAttribute(name = USER_ID_KEY) String userId) {
         Long spendingId = spendingService.createSpending(
             LocalDateTime.parse(request.getDate()),
             request.getAmount(),

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -11,6 +11,7 @@ import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingLis
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingResponse;
 import com.wealdy.saemsembackend.domain.spending.service.SpendingService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,8 +51,8 @@ public class SpendingController {
         @RequestParam LocalDate startDate,
         @RequestParam LocalDate endDate,
         @RequestParam(required = false) List<String> category,
-        @RequestParam(required = false) Long minAmount,
-        @RequestParam(required = false) Long maxAmount,
+        @RequestParam(required = false) @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.") Long minAmount,
+        @RequestParam(required = false) @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.") Long maxAmount,
         @RequestAttribute(name = USER_ID_KEY) String userId
     ) {
         ListResponseDto<SpendingResponse> spendingList = ListResponseDto.from(

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -10,7 +10,6 @@ import com.wealdy.saemsembackend.domain.spending.controller.request.CreateSpendi
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingListResponse;
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingResponse;
 import com.wealdy.saemsembackend.domain.spending.service.SpendingService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
@@ -19,6 +18,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -32,8 +32,7 @@ public class SpendingController {
     private final SpendingService spendingService;
 
     @PostMapping
-    public Response<IdResponseDto> create(@Valid @RequestBody CreateSpendingRequest request, HttpServletRequest httpRequest) {
-        String userId = String.valueOf(httpRequest.getAttribute(USER_ID_KEY));
+    public Response<IdResponseDto> create(@Valid @RequestBody CreateSpendingRequest request, @RequestAttribute(name = USER_ID_KEY) String userId) {
         Long spendingId = spendingService.createSpending(
             request.getDate(), request.getAmount(), request.getMemo(), request.isExcludeTotal(), request.getCategoryName(), userId);
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -40,8 +40,8 @@ public class SpendingController {
     }
 
     @GetMapping("/{spendingId}")
-    public Response<SpendingResponse> getSpending(@PathVariable Long spendingId) {
-        return Response.of(SpendingResponse.from(spendingService.getSpending(spendingId)));
+    public Response<SpendingResponse> getSpending(@PathVariable Long spendingId, @RequestAttribute(name = USER_ID_KEY) String userId) {
+        return Response.of(SpendingResponse.from(spendingService.getSpending(spendingId, userId)));
     }
 
     @GetMapping

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -57,10 +57,11 @@ public class SpendingController {
             spendingService.getSpendingList(startDate, endDate, category, minAmount, maxAmount, userId).stream()
                 .map(SpendingResponse::from)
                 .toList());
-        long sumOfAmount = spendingService.getSumOfAmountByDate(startDate, endDate, userId);
-        List<SpendingSummaryDto> sumOfAmountByCategory = spendingService.getSumOfAmountByCategory(startDate, endDate, userId).stream()
-            .map(SpendingSummaryDto::from)
-            .toList();
+        long sumOfAmount = spendingService.getSumOfAmountByDate(startDate, endDate, category, minAmount, maxAmount, userId);
+        List<SpendingSummaryDto> sumOfAmountByCategory =
+            spendingService.getSumOfAmountByCategory(startDate, endDate, category, minAmount, maxAmount, userId).stream()
+                .map(SpendingSummaryDto::from)
+                .toList();
 
         return Response.of(SpendingListResponse.of(sumOfAmount, sumOfAmountByCategory, spendingList));
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -37,7 +38,13 @@ public class SpendingController {
     @PostMapping
     public Response<IdResponseDto> create(@Valid @RequestBody SaveSpendingRequest request, @RequestAttribute(name = USER_ID_KEY) String userId) {
         Long spendingId = spendingService.createSpending(
-            request.getDate(), request.getAmount(), request.getMemo(), request.isExcludeTotal(), request.getCategoryName(), userId);
+            LocalDateTime.parse(request.getDate()),
+            request.getAmount(),
+            request.getMemo(),
+            request.isExcludeTotal(),
+            request.getCategoryName(),
+            userId
+        );
 
         return Response.of(IdResponseDto.from(spendingId));
     }
@@ -79,7 +86,14 @@ public class SpendingController {
         @RequestAttribute(name = USER_ID_KEY) String userId
     ) {
         spendingService.updateSpending(
-            spendingId, request.getDate(), request.getAmount(), request.getMemo(), request.isExcludeTotal(), request.getCategoryName(), userId);
+            spendingId,
+            LocalDateTime.parse(request.getDate()),
+            request.getAmount(),
+            request.getMemo(),
+            request.isExcludeTotal(),
+            request.getCategoryName(),
+            userId
+        );
 
         return Response.of(IdResponseDto.from(spendingId));
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -7,6 +7,7 @@ import com.wealdy.saemsembackend.domain.core.response.ListResponseDto;
 import com.wealdy.saemsembackend.domain.core.response.Response;
 import com.wealdy.saemsembackend.domain.spending.controller.dto.SpendingSummaryDto;
 import com.wealdy.saemsembackend.domain.spending.controller.request.SaveSpendingRequest;
+import com.wealdy.saemsembackend.domain.spending.controller.request.UpdateExcludeRequest;
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingListResponse;
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingResponse;
 import com.wealdy.saemsembackend.domain.spending.service.SpendingService;
@@ -38,7 +39,10 @@ public class SpendingController {
     private final SpendingService spendingService;
 
     @PostMapping
-    public Response<IdResponseDto> createSpending(@Valid @RequestBody SaveSpendingRequest request, @RequestAttribute(name = USER_ID_KEY) String userId) {
+    public Response<IdResponseDto> createSpending(
+        @Valid @RequestBody SaveSpendingRequest request,
+        @RequestAttribute(name = USER_ID_KEY) String userId
+    ) {
         Long spendingId = spendingService.createSpending(
             LocalDateTime.parse(request.getDate()),
             request.getAmount(),
@@ -96,6 +100,17 @@ public class SpendingController {
             request.getCategoryName(),
             userId
         );
+
+        return Response.of(IdResponseDto.from(spendingId));
+    }
+
+    @PutMapping("/exclude/{spendingId}")
+    public Response<IdResponseDto> updateExclude(
+        @PathVariable Long spendingId,
+        @Valid @RequestBody UpdateExcludeRequest request,
+        @RequestAttribute(name = USER_ID_KEY) String userId
+    ) {
+        spendingService.updateExclude(spendingId, request.getExcludeTotal(), userId);
 
         return Response.of(IdResponseDto.from(spendingId));
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -50,14 +50,15 @@ public class SpendingController {
         @RequestParam LocalDate endDate,
         @RequestParam(required = false) List<String> category,
         @RequestParam(required = false) Long minAmount,
-        @RequestParam(required = false) Long maxAmount
+        @RequestParam(required = false) Long maxAmount,
+        @RequestAttribute(name = USER_ID_KEY) String userId
     ) {
         ListResponseDto<SpendingResponse> spendingList = ListResponseDto.from(
-            spendingService.getSpendingList(startDate, endDate, category, minAmount, maxAmount).stream()
+            spendingService.getSpendingList(startDate, endDate, category, minAmount, maxAmount, userId).stream()
                 .map(SpendingResponse::from)
                 .toList());
-        long sumOfAmount = spendingService.getSumOfAmountByDate(startDate, endDate);
-        List<SpendingSummaryDto> sumOfAmountByCategory = spendingService.getSumOfAmountByCategory(startDate, endDate).stream()
+        long sumOfAmount = spendingService.getSumOfAmountByDate(startDate, endDate, userId);
+        List<SpendingSummaryDto> sumOfAmountByCategory = spendingService.getSumOfAmountByCategory(startDate, endDate, userId).stream()
             .map(SpendingSummaryDto::from)
             .toList();
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -6,7 +6,7 @@ import com.wealdy.saemsembackend.domain.core.response.IdResponseDto;
 import com.wealdy.saemsembackend.domain.core.response.ListResponseDto;
 import com.wealdy.saemsembackend.domain.core.response.Response;
 import com.wealdy.saemsembackend.domain.spending.controller.dto.SpendingSummaryDto;
-import com.wealdy.saemsembackend.domain.spending.controller.request.CreateSpendingRequest;
+import com.wealdy.saemsembackend.domain.spending.controller.request.SaveSpendingRequest;
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingListResponse;
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingResponse;
 import com.wealdy.saemsembackend.domain.spending.service.SpendingService;
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,7 +33,7 @@ public class SpendingController {
     private final SpendingService spendingService;
 
     @PostMapping
-    public Response<IdResponseDto> create(@Valid @RequestBody CreateSpendingRequest request, @RequestAttribute(name = USER_ID_KEY) String userId) {
+    public Response<IdResponseDto> create(@Valid @RequestBody SaveSpendingRequest request, @RequestAttribute(name = USER_ID_KEY) String userId) {
         Long spendingId = spendingService.createSpending(
             request.getDate(), request.getAmount(), request.getMemo(), request.isExcludeTotal(), request.getCategoryName(), userId);
 
@@ -64,6 +65,18 @@ public class SpendingController {
                 .toList();
 
         return Response.of(SpendingListResponse.of(sumOfAmount, sumOfAmountByCategory, spendingList));
+    }
+
+    @PutMapping("/{spendingId}")
+    public Response<IdResponseDto> update(
+        @PathVariable Long spendingId,
+        @Valid @RequestBody SaveSpendingRequest request,
+        @RequestAttribute(name = USER_ID_KEY) String userId
+    ) {
+        spendingService.updateSpending(
+            spendingId, request.getDate(), request.getAmount(), request.getMemo(), request.isExcludeTotal(), request.getCategoryName(), userId);
+
+        return Response.of(IdResponseDto.from(spendingId));
     }
 
     @DeleteMapping("/{spendingId}")

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -17,6 +17,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/spendings")
+@Validated
 public class SpendingController {
 
     private final SpendingService spendingService;

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -65,8 +65,8 @@ public class SpendingController {
     }
 
     @DeleteMapping("/{spendingId}")
-    public Response<Void> deleteSpending(@PathVariable Long spendingId) {
-        spendingService.deleteSpending(spendingId);
+    public Response<Void> deleteSpending(@PathVariable Long spendingId, @RequestAttribute(name = USER_ID_KEY) String userId) {
+        spendingService.deleteSpending(spendingId, userId);
         return Response.OK;
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -6,8 +6,9 @@ import com.wealdy.saemsembackend.domain.core.response.IdResponseDto;
 import com.wealdy.saemsembackend.domain.core.response.ListResponseDto;
 import com.wealdy.saemsembackend.domain.core.response.Response;
 import com.wealdy.saemsembackend.domain.spending.controller.dto.SpendingSummaryDto;
-import com.wealdy.saemsembackend.domain.spending.controller.request.SaveSpendingRequest;
+import com.wealdy.saemsembackend.domain.spending.controller.request.CreateSpendingRequest;
 import com.wealdy.saemsembackend.domain.spending.controller.request.UpdateExcludeRequest;
+import com.wealdy.saemsembackend.domain.spending.controller.request.UpdateSpendingRequest;
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingListResponse;
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingResponse;
 import com.wealdy.saemsembackend.domain.spending.service.SpendingService;
@@ -40,7 +41,7 @@ public class SpendingController {
 
     @PostMapping
     public Response<IdResponseDto> createSpending(
-        @Valid @RequestBody SaveSpendingRequest request,
+        @Valid @RequestBody CreateSpendingRequest request,
         @RequestAttribute(name = USER_ID_KEY) String userId
     ) {
         Long spendingId = spendingService.createSpending(
@@ -88,7 +89,7 @@ public class SpendingController {
     @PutMapping("/{spendingId}")
     public Response<IdResponseDto> update(
         @PathVariable Long spendingId,
-        @Valid @RequestBody SaveSpendingRequest request,
+        @Valid @RequestBody UpdateSpendingRequest request,
         @RequestAttribute(name = USER_ID_KEY) String userId
     ) {
         spendingService.updateSpending(
@@ -96,7 +97,6 @@ public class SpendingController {
             LocalDateTime.parse(request.getDate()),
             request.getAmount(),
             request.getMemo(),
-            request.isExcludeTotal(),
             request.getCategoryName(),
             userId
         );

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -11,6 +11,7 @@ import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingLis
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingResponse;
 import com.wealdy.saemsembackend.domain.spending.service.SpendingService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.time.LocalDate;
 import java.util.List;
@@ -48,20 +49,23 @@ public class SpendingController {
 
     @GetMapping
     public Response<SpendingListResponse> getSpendingList(
-        @RequestParam LocalDate startDate,
-        @RequestParam LocalDate endDate,
+        @RequestParam @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 'yyyy-MM-dd' 으로 입력해야 합니다.") String startDate,
+        @RequestParam @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 'yyyy-MM-dd' 으로 입력해야 합니다.") String endDate,
         @RequestParam(required = false) List<String> category,
         @RequestParam(required = false) @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.") Long minAmount,
         @RequestParam(required = false) @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.") Long maxAmount,
         @RequestAttribute(name = USER_ID_KEY) String userId
     ) {
+        LocalDate startLocalDate = LocalDate.parse(startDate);
+        LocalDate endLocalDate = LocalDate.parse(endDate);
+
         ListResponseDto<SpendingResponse> spendingList = ListResponseDto.from(
-            spendingService.getSpendingList(startDate, endDate, category, minAmount, maxAmount, userId).stream()
+            spendingService.getSpendingList(startLocalDate, endLocalDate, category, minAmount, maxAmount, userId).stream()
                 .map(SpendingResponse::from)
                 .toList());
-        long sumOfAmount = spendingService.getSumOfAmountByDate(startDate, endDate, category, minAmount, maxAmount, userId);
+        long sumOfAmount = spendingService.getSumOfAmountByDate(startLocalDate, endLocalDate, category, minAmount, maxAmount, userId);
         List<SpendingSummaryDto> sumOfAmountByCategory =
-            spendingService.getSumOfAmountByCategory(startDate, endDate, category, minAmount, maxAmount, userId).stream()
+            spendingService.getSumOfAmountByCategory(startLocalDate, endLocalDate, category, minAmount, maxAmount, userId).stream()
                 .map(SpendingSummaryDto::from)
                 .toList();
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/dto/SpendingSummaryDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/dto/SpendingSummaryDto.java
@@ -1,0 +1,18 @@
+package com.wealdy.saemsembackend.domain.spending.controller.dto;
+
+import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingSummaryDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class SpendingSummaryDto {
+
+    private String categoryName;
+    private long amount;
+
+    public static SpendingSummaryDto from(GetSpendingSummaryDto getSpendingSummaryDto) {
+        return new SpendingSummaryDto(getSpendingSummaryDto.getCategoryName(), getSpendingSummaryDto.getAmount());
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/dto/SpendingSummaryDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/dto/SpendingSummaryDto.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 @Getter
 public class SpendingSummaryDto {
 
-    private String categoryName;
-    private long amount;
+    private final String categoryName;
+    private final long amount;
 
     public static SpendingSummaryDto from(GetSpendingSummaryDto getSpendingSummaryDto) {
         return new SpendingSummaryDto(getSpendingSummaryDto.getCategoryName(), getSpendingSummaryDto.getAmount());

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/CreateSpendingRequest.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/CreateSpendingRequest.java
@@ -1,8 +1,8 @@
 package com.wealdy.saemsembackend.domain.spending.controller.request;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -16,7 +16,7 @@ public class CreateSpendingRequest {
     @NotNull(message = "날짜는 필수 값입니다.")
     private LocalDateTime date;
 
-    @Min(value = 0, message = "금액은 0원 이상으로 입력해야 합니다.")
+    @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.")
     private long amount;
 
     @Size(max = 200, message = "메모는 200자까지 입력할 수 있습니다.")

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/CreateSpendingRequest.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/CreateSpendingRequest.java
@@ -17,7 +17,7 @@ public class CreateSpendingRequest {
     private LocalDateTime date;
 
     @Min(value = 0, message = "금액은 0원 이상으로 입력해야 합니다.")
-    private int amount;
+    private long amount;
 
     @Size(max = 200, message = "메모는 200자까지 입력할 수 있습니다.")
     private String memo;

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/CreateSpendingRequest.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/CreateSpendingRequest.java
@@ -1,0 +1,26 @@
+package com.wealdy.saemsembackend.domain.spending.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class CreateSpendingRequest {
+
+    @NotBlank(message = "카테고리는 필수 값입니다.")
+    private String categoryName;
+
+    @NotBlank(message = "날짜는 필수 값입니다.")
+    @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}", message = "날짜 형식은 'yyyy-MM-dd'T'HH:mm:ss' 으로 입력해야 합니다.")
+    private String date;
+
+    @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.")
+    private long amount;
+
+    @Size(max = 200, message = "메모는 200자까지 입력할 수 있습니다.")
+    private String memo;
+
+    private boolean excludeTotal;
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/SaveSpendingRequest.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/SaveSpendingRequest.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
-public class CreateSpendingRequest {
+public class SaveSpendingRequest {
 
     @NotBlank(message = "카테고리는 필수 값입니다.")
     private String categoryName;

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/SaveSpendingRequest.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/SaveSpendingRequest.java
@@ -1,10 +1,9 @@
 package com.wealdy.saemsembackend.domain.spending.controller.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
@@ -13,8 +12,9 @@ public class SaveSpendingRequest {
     @NotBlank(message = "카테고리는 필수 값입니다.")
     private String categoryName;
 
-    @NotNull(message = "날짜는 필수 값입니다.")
-    private LocalDateTime date;
+    @NotBlank(message = "날짜는 필수 값입니다.")
+    @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}", message = "날짜 형식은 'yyyy-MM-dd'T'HH:mm:ss' 으로 입력해야 합니다.")
+    private String date;
 
     @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.")
     private long amount;

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/UpdateExcludeRequest.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/UpdateExcludeRequest.java
@@ -1,0 +1,11 @@
+package com.wealdy.saemsembackend.domain.spending.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UpdateExcludeRequest {
+
+    @NotNull(message = "합계 제외 여부는 필수 값입니다.")
+    private Boolean excludeTotal;
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/UpdateSpendingRequest.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/request/UpdateSpendingRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
-public class SaveSpendingRequest {
+public class UpdateSpendingRequest {
 
     @NotBlank(message = "카테고리는 필수 값입니다.")
     private String categoryName;
@@ -21,6 +21,4 @@ public class SaveSpendingRequest {
 
     @Size(max = 200, message = "메모는 200자까지 입력할 수 있습니다.")
     private String memo;
-
-    private boolean excludeTotal;
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/response/SpendingListResponse.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/response/SpendingListResponse.java
@@ -1,0 +1,22 @@
+package com.wealdy.saemsembackend.domain.spending.controller.response;
+
+import com.wealdy.saemsembackend.domain.core.response.ListResponseDto;
+import com.wealdy.saemsembackend.domain.spending.controller.dto.SpendingSummaryDto;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class SpendingListResponse {
+
+    private long spendingTotal;
+    private List<SpendingSummaryDto> spendingTotalByCategory;
+    private ListResponseDto<SpendingResponse> spendingList;
+
+    public static SpendingListResponse of(long spendingTotal, List<SpendingSummaryDto> spendingTotalByCategory,
+        ListResponseDto<SpendingResponse> spendingList) {
+        return new SpendingListResponse(spendingTotal, spendingTotalByCategory, spendingList);
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/response/SpendingListResponse.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/response/SpendingListResponse.java
@@ -11,9 +11,9 @@ import lombok.Getter;
 @Getter
 public class SpendingListResponse {
 
-    private long spendingTotal;
-    private List<SpendingSummaryDto> spendingTotalByCategory;
-    private ListResponseDto<SpendingResponse> spendingList;
+    private final long spendingTotal;
+    private final List<SpendingSummaryDto> spendingTotalByCategory;
+    private final ListResponseDto<SpendingResponse> spendingList;
 
     public static SpendingListResponse of(long spendingTotal, List<SpendingSummaryDto> spendingTotalByCategory,
         ListResponseDto<SpendingResponse> spendingList) {

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/response/SpendingResponse.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/response/SpendingResponse.java
@@ -14,7 +14,7 @@ public class SpendingResponse {
     private Long id;
     private String categoryName;
     private LocalDateTime date;
-    private int amount;
+    private long amount;
     private String memo;
     private YnColumn excludeTotal;
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/response/SpendingResponse.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/response/SpendingResponse.java
@@ -11,12 +11,12 @@ import lombok.Getter;
 @Getter
 public class SpendingResponse {
 
-    private Long id;
-    private String categoryName;
-    private LocalDateTime date;
-    private long amount;
-    private String memo;
-    private YnColumn excludeTotal;
+    private final Long id;
+    private final String categoryName;
+    private final LocalDateTime date;
+    private final long amount;
+    private final String memo;
+    private final YnColumn excludeTotal;
 
     public static SpendingResponse from(GetSpendingDto getSpendingDto) {
         return new SpendingResponse(

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
@@ -38,7 +38,7 @@ public class Spending {
     @Column(length = 200)
     private String memo;  // 메모
 
-    @ColumnDefault("N")
+    @ColumnDefault("'N'")
     @Column(nullable = false, length = 1)
     @Enumerated(EnumType.STRING)
     private YnColumn excludeTotal;  // 지출 합계 제외 여부

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
@@ -70,4 +70,12 @@ public class Spending {
             category
         );
     }
+
+    public void updateSpending(LocalDateTime date, long amount, String memo, boolean excludeTotal, Category category) {
+        this.date = date;
+        this.amount = amount;
+        this.memo = memo;
+        this.excludeTotal = YnColumn.from(excludeTotal);
+        this.category = category;
+    }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
@@ -55,7 +55,7 @@ public class Spending {
         this.date = date;
         this.amount = amount;
         this.memo = memo;
-        this.excludeTotal = YnColumn.fromBoolean(excludeTotal);
+        this.excludeTotal = YnColumn.from(excludeTotal);
         this.user = user;
         this.category = category;
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
@@ -71,11 +71,10 @@ public class Spending {
         );
     }
 
-    public void updateSpending(LocalDateTime date, long amount, String memo, boolean excludeTotal, Category category) {
+    public void updateSpending(LocalDateTime date, long amount, String memo, Category category) {
         this.date = date;
         this.amount = amount;
         this.memo = memo;
-        this.excludeTotal = YnColumn.from(excludeTotal);
         this.category = category;
     }
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
@@ -78,4 +78,8 @@ public class Spending {
         this.excludeTotal = YnColumn.from(excludeTotal);
         this.category = category;
     }
+
+    public void updateExclude(boolean excludeTotal) {
+        this.excludeTotal = YnColumn.from(excludeTotal);
+    }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/entity/Spending.java
@@ -33,7 +33,7 @@ public class Spending {
     private LocalDateTime date;  // 지출일시
 
     @Column(nullable = false)
-    private int amount;  // 금액
+    private long amount;  // 금액
 
     @Column(length = 200)
     private String memo;  // 메모
@@ -51,7 +51,7 @@ public class Spending {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;  // 카테고리
 
-    private Spending(LocalDateTime date, int amount, String memo, boolean excludeTotal, User user, Category category) {
+    private Spending(LocalDateTime date, long amount, String memo, boolean excludeTotal, User user, Category category) {
         this.date = date;
         this.amount = amount;
         this.memo = memo;
@@ -60,7 +60,7 @@ public class Spending {
         this.category = category;
     }
 
-    public static Spending createSpending(LocalDateTime date, int amount, String memo, boolean excludeTotal, User user, Category category) {
+    public static Spending createSpending(LocalDateTime date, long amount, String memo, boolean excludeTotal, User user, Category category) {
         return new Spending(
             date,
             amount,

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
@@ -2,13 +2,17 @@ package com.wealdy.saemsembackend.domain.spending.repository;
 
 import com.wealdy.saemsembackend.domain.spending.entity.Spending;
 import com.wealdy.saemsembackend.domain.spending.repository.projection.SpendingSummaryProjection;
+import com.wealdy.saemsembackend.domain.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface SpendingRepository extends JpaRepository<Spending, Long> {
+
+    Optional<Spending> findByIdAndUser(Long id, User user);
 
     @Query(value = "select s from Spending s join fetch s.category where s.date between :startDate and :endDate order by s.date desc")
     List<Spending> findByDateBetweenOrderByDateDesc(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
@@ -7,41 +7,64 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface SpendingRepository extends JpaRepository<Spending, Long> {
+public interface SpendingRepository extends JpaRepository<Spending, Long>, JpaSpecificationExecutor<Spending> {
 
     Optional<Spending> findByIdAndUser(Long id, User user);
 
     @Query(value = "select s from Spending s join fetch s.category "
-        + "where s.date between :startDate and :endDate and s.user = :user order by s.date desc")
+        + "where s.date between :startDate and :endDate and s.user = :user "
+        + "and (:minAmount is null or s.amount >= :minAmount) "
+        + "and (:maxAmount is null or s.amount <= :maxAmount) "
+        + "and (:category is null or s.category.name in :category) "
+        + "order by s.date desc")
     List<Spending> findByDateBetweenOrderByDateDesc(
         @Param("startDate") LocalDateTime startDate,
         @Param("endDate") LocalDateTime endDate,
+        @Param("category") List<String> category,
+        @Param("minAmount") Long minAmount,
+        @Param("maxAmount") Long maxAmount,
         @Param("user") User user
     );
 
     @Query(value = "select case when sum(s.amount) is null then 0 else sum(s.amount) end "
-        + "from Spending s where s.excludeTotal = 'N' and s.date between :startDate and :endDate and s.user = :user")
-    long getSumOfAmountByDate(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("user") User user);
+        + "from Spending s where s.excludeTotal = 'N' and s.date between :startDate and :endDate and s.user = :user "
+        + "and (:minAmount is null or s.amount >= :minAmount) "
+        + "and (:maxAmount is null or s.amount <= :maxAmount) "
+        + "and (:category is null or s.category.name in :category)")
+    long getSumOfAmountByDate(
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate,
+        @Param("category") List<String> category,
+        @Param("minAmount") Long minAmount,
+        @Param("maxAmount") Long maxAmount,
+        @Param("user") User user
+    );
 
-    // 합계가 0인 카테고리는 select 되지 않음
-//    @Query(value = "select s.category.name as categoryName, sum(s.amount) as amount from Spending s join s.category c "
-//        + "where s.excludeTotal = 'N' and s.date between :startDate and :endDate group by s.category")
     @Query(nativeQuery = true,
         value = "select categoryName, sum(amount) as amount "
             + "from (select c.name as categoryName, sum(s.amount) as amount from spending s "
             + "left join category c on c.category_id = s.category_id "
             + "where s.exclude_total='N' and s.date between :startDate and :endDate and s.user_id = :userId "
-            + "group by c.category_id "
+            + "and (:minAmount is null or s.amount >= :minAmount) "
+            + "and (:maxAmount is null or s.amount <= :maxAmount) "
+            + "and (:categorySize = 0 or c.name in (:category)) "
+            + "group by c.name "
             + "union "
             + "select c.name as categoryName, 0 as amount from spending s "
-            + "right join category c on c.category_id = s.category_id) as spendingByCategory group by categoryName order by amount desc"
+            + "right join category c on c.category_id = s.category_id) "
+            + "as spendingByCategory group by categoryName order by amount desc"
     )
     List<SpendingSummaryProjection> getSumOfAmountByCategory(
         @Param("startDate") LocalDateTime startDate,
         @Param("endDate") LocalDateTime endDate,
+        @Param("categorySize") int categorySize,
+        @Param("category") List<String> category,
+        @Param("minAmount") Long minAmount,
+        @Param("maxAmount") Long maxAmount,
         @Param("userId") String userId
     );
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
@@ -1,8 +1,33 @@
 package com.wealdy.saemsembackend.domain.spending.repository;
 
 import com.wealdy.saemsembackend.domain.spending.entity.Spending;
+import com.wealdy.saemsembackend.domain.spending.repository.projection.SpendingSummaryProjection;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SpendingRepository extends JpaRepository<Spending, Long> {
 
+    @Query(value = "select s from Spending s join fetch s.category where s.date between :startDate and :endDate order by s.date desc")
+    List<Spending> findByDateBetweenOrderByDateDesc(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    @Query(value = "select sum(s.amount) from Spending s where s.excludeTotal = 'N' and s.date between :startDate and :endDate")
+    long getSumOfAmountByDate(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    // 합계가 0인 카테고리는 select 되지 않음
+//    @Query(value = "select s.category.name as categoryName, sum(s.amount) as amount from Spending s join s.category c "
+//        + "where s.excludeTotal = 'N' and s.date between :startDate and :endDate group by s.category")
+    @Query(nativeQuery = true,
+        value = "select categoryName, sum(amount) as amount "
+            + "from (select c.name as categoryName, sum(s.amount) as amount from spending s "
+            + "left join category c on c.category_id = s.category_id "
+            + "where s.exclude_total='N' and s.date between '2024-01-01T00:00' and '2024-01-02T23:59:59' "
+            + "group by c.category_id "
+            + "union "
+            + "select c.name as categoryName, 0 as amount from spending s "
+            + "right join category c on c.category_id = s.category_id) as spendingByCategory group by categoryName order by amount desc"
+    )
+    List<SpendingSummaryProjection> getSumOfAmountByCategory(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
@@ -14,12 +14,17 @@ public interface SpendingRepository extends JpaRepository<Spending, Long> {
 
     Optional<Spending> findByIdAndUser(Long id, User user);
 
-    @Query(value = "select s from Spending s join fetch s.category where s.date between :startDate and :endDate order by s.date desc")
-    List<Spending> findByDateBetweenOrderByDateDesc(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+    @Query(value = "select s from Spending s join fetch s.category "
+        + "where s.date between :startDate and :endDate and s.user = :user order by s.date desc")
+    List<Spending> findByDateBetweenOrderByDateDesc(
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate,
+        @Param("user") User user
+    );
 
     @Query(value = "select case when sum(s.amount) is null then 0 else sum(s.amount) end "
-        + "from Spending s where s.excludeTotal = 'N' and s.date between :startDate and :endDate")
-    long getSumOfAmountByDate(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+        + "from Spending s where s.excludeTotal = 'N' and s.date between :startDate and :endDate and s.user = :user")
+    long getSumOfAmountByDate(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("user") User user);
 
     // 합계가 0인 카테고리는 select 되지 않음
 //    @Query(value = "select s.category.name as categoryName, sum(s.amount) as amount from Spending s join s.category c "
@@ -28,11 +33,15 @@ public interface SpendingRepository extends JpaRepository<Spending, Long> {
         value = "select categoryName, sum(amount) as amount "
             + "from (select c.name as categoryName, sum(s.amount) as amount from spending s "
             + "left join category c on c.category_id = s.category_id "
-            + "where s.exclude_total='N' and s.date between :startDate and :endDate "
+            + "where s.exclude_total='N' and s.date between :startDate and :endDate and s.user_id = :userId "
             + "group by c.category_id "
             + "union "
             + "select c.name as categoryName, 0 as amount from spending s "
             + "right join category c on c.category_id = s.category_id) as spendingByCategory group by categoryName order by amount desc"
     )
-    List<SpendingSummaryProjection> getSumOfAmountByCategory(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+    List<SpendingSummaryProjection> getSumOfAmountByCategory(
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate,
+        @Param("userId") String userId
+    );
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
@@ -17,7 +17,8 @@ public interface SpendingRepository extends JpaRepository<Spending, Long> {
     @Query(value = "select s from Spending s join fetch s.category where s.date between :startDate and :endDate order by s.date desc")
     List<Spending> findByDateBetweenOrderByDateDesc(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
-    @Query(value = "select sum(s.amount) from Spending s where s.excludeTotal = 'N' and s.date between :startDate and :endDate")
+    @Query(value = "select case when sum(s.amount) is null then 0 else sum(s.amount) end "
+        + "from Spending s where s.excludeTotal = 'N' and s.date between :startDate and :endDate")
     long getSumOfAmountByDate(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
     // 합계가 0인 카테고리는 select 되지 않음
@@ -27,7 +28,7 @@ public interface SpendingRepository extends JpaRepository<Spending, Long> {
         value = "select categoryName, sum(amount) as amount "
             + "from (select c.name as categoryName, sum(s.amount) as amount from spending s "
             + "left join category c on c.category_id = s.category_id "
-            + "where s.exclude_total='N' and s.date between '2024-01-01T00:00' and '2024-01-02T23:59:59' "
+            + "where s.exclude_total='N' and s.date between :startDate and :endDate "
             + "group by c.category_id "
             + "union "
             + "select c.name as categoryName, 0 as amount from spending s "

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/projection/SpendingSummaryProjection.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/projection/SpendingSummaryProjection.java
@@ -1,0 +1,7 @@
+package com.wealdy.saemsembackend.domain.spending.repository.projection;
+
+public interface SpendingSummaryProjection {
+
+    String getCategoryName();
+    Long getAmount();
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -68,8 +68,9 @@ public class SpendingService {
     }
 
     @Transactional
-    public void deleteSpending(Long spendingId) {
-        Spending spending = spendingRepository.findById(spendingId)
+    public void deleteSpending(Long spendingId, String userId) {
+        User user = userService.getUserById(userId);
+        Spending spending = spendingRepository.findByIdAndUser(spendingId, user)
             .orElseThrow(() -> new NotFoundException(NOT_FOUND_SPENDING));
         spendingRepository.delete(spending);
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -36,8 +36,9 @@ public class SpendingService {
         return spending.getId();
     }
 
-    public GetSpendingDto getSpending(Long spendingId) {
-        Spending spending = spendingRepository.findById(spendingId)
+    public GetSpendingDto getSpending(Long spendingId, String userId) {
+        User user = userService.getUserById(userId);
+        Spending spending = spendingRepository.findByIdAndUser(spendingId, user)
             .orElseThrow(() -> new NotFoundException(NOT_FOUND_SPENDING));
         return GetSpendingDto.from(spending);
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -47,6 +47,14 @@ public class SpendingService {
         spending.updateSpending(date, amount, memo, excludeTotal, category);
     }
 
+    @Transactional
+    public void updateExclude(Long spendingId, boolean excludeTotal, String userId) {
+        User user = userService.getUserById(userId);
+
+        Spending spending = getSpending(spendingId, user);
+        spending.updateExclude(excludeTotal);
+    }
+
     public GetSpendingDto getSpending(Long spendingId, String userId) {
         User user = userService.getUserById(userId);
         Spending spending = getSpending(spendingId, user);

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -10,7 +10,7 @@ import com.wealdy.saemsembackend.domain.spending.repository.SpendingRepository;
 import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingDto;
 import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingSummaryDto;
 import com.wealdy.saemsembackend.domain.user.entity.User;
-import com.wealdy.saemsembackend.domain.user.repository.UserRepository;
+import com.wealdy.saemsembackend.domain.user.service.UserService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -25,11 +25,11 @@ public class SpendingService {
 
     private final SpendingRepository spendingRepository;
     private final CategoryService categoryService;
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     @Transactional
     public Long createSpending(LocalDateTime date, long amount, String memo, boolean excludeTotal, String categoryName, String userId) {
-        User user = userRepository.findById(userId).get(0);
+        User user = userService.getUserById(userId);
         Category category = categoryService.getCategoryByName(categoryName);
 
         Spending spending = spendingRepository.save(Spending.createSpending(date, amount, memo, excludeTotal, user, category));
@@ -37,7 +37,8 @@ public class SpendingService {
     }
 
     public GetSpendingDto getSpending(Long spendingId) {
-        Spending spending = spendingRepository.findById(spendingId).orElseThrow(() -> new NotFoundException(NOT_FOUND_SPENDING));
+        Spending spending = spendingRepository.findById(spendingId)
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_SPENDING));
         return GetSpendingDto.from(spending);
     }
 
@@ -68,7 +69,8 @@ public class SpendingService {
 
     @Transactional
     public void deleteSpending(Long spendingId) {
-        Spending spending = spendingRepository.findById(spendingId).orElseThrow(() -> new NotFoundException(NOT_FOUND_SPENDING));
+        Spending spending = spendingRepository.findById(spendingId)
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_SPENDING));
         spendingRepository.delete(spending);
     }
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -38,13 +38,13 @@ public class SpendingService {
 
     @Transactional
     public void updateSpending(
-        Long spendingId, LocalDateTime date, long amount, String memo, boolean excludeTotal, String categoryName, String userId
+        Long spendingId, LocalDateTime date, long amount, String memo, String categoryName, String userId
     ) {
         User user = userService.getUserById(userId);
         Category category = categoryService.getCategory(categoryName);
 
         Spending spending = getSpending(spendingId, user);
-        spending.updateSpending(date, amount, memo, excludeTotal, category);
+        spending.updateSpending(date, amount, memo, category);
     }
 
     @Transactional

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -53,6 +53,7 @@ public class SpendingService {
         return GetSpendingDto.from(spending);
     }
 
+    @Transactional(readOnly = true)
     public List<GetSpendingDto> getSpendingList(
         LocalDate startDate,
         LocalDate endDate,
@@ -71,6 +72,7 @@ public class SpendingService {
             .toList();
     }
 
+    @Transactional(readOnly = true)
     public List<GetSpendingSummaryDto> getSumOfAmountByCategory(
         LocalDate startDate,
         LocalDate endDate,
@@ -89,6 +91,7 @@ public class SpendingService {
             .toList();
     }
 
+    @Transactional(readOnly = true)
     public long getSumOfAmountByDate(
         LocalDate startDate,
         LocalDate endDate,

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -30,7 +30,7 @@ public class SpendingService {
     @Transactional
     public Long createSpending(LocalDateTime date, long amount, String memo, boolean excludeTotal, String categoryName, String userId) {
         User user = userRepository.findById(userId).get(0);
-        Category category = categoryService.findByName(categoryName);
+        Category category = categoryService.getCategoryByName(categoryName);
 
         Spending spending = spendingRepository.save(Spending.createSpending(date, amount, memo, excludeTotal, user, category));
         return spending.getId();

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -56,27 +56,43 @@ public class SpendingService {
         LocalDateTime startDateTime = getStartDateTime(startDate);
         LocalDateTime endDateTime = getEndDateTime(endDate);
 
-        return spendingRepository.findByDateBetweenOrderByDateDesc(startDateTime, endDateTime, user).stream()
+        return spendingRepository.findByDateBetweenOrderByDateDesc(startDateTime, endDateTime, category, minAmount, maxAmount, user).stream()
             .map(GetSpendingDto::from)
             .toList();
     }
 
-    public List<GetSpendingSummaryDto> getSumOfAmountByCategory(LocalDate startDate, LocalDate endDate, String userId) {
+    public List<GetSpendingSummaryDto> getSumOfAmountByCategory(
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> category,
+        Long minAmount,
+        Long maxAmount,
+        String userId
+    ) {
         LocalDateTime startDateTime = getStartDateTime(startDate);
         LocalDateTime endDateTime = getEndDateTime(endDate);
 
-        return spendingRepository.getSumOfAmountByCategory(startDateTime, endDateTime, userId).stream()
+        int categorySize = (category != null) ? category.size() : 0;
+
+        return spendingRepository.getSumOfAmountByCategory(startDateTime, endDateTime, categorySize, category, minAmount, maxAmount, userId).stream()
             .map(projection -> GetSpendingSummaryDto.of(projection.getCategoryName(), projection.getAmount()))
             .toList();
     }
 
-    public long getSumOfAmountByDate(LocalDate startDate, LocalDate endDate, String userId) {
+    public long getSumOfAmountByDate(
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> category,
+        Long minAmount,
+        Long maxAmount,
+        String userId
+    ) {
         User user = userService.getUserById(userId);
 
         LocalDateTime startDateTime = getStartDateTime(startDate);
         LocalDateTime endDateTime = getEndDateTime(endDate);
 
-        return spendingRepository.getSumOfAmountByDate(startDateTime, endDateTime, user);
+        return spendingRepository.getSumOfAmountByDate(startDateTime, endDateTime, category, minAmount, maxAmount, user);
     }
 
     @Transactional

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -30,7 +30,7 @@ public class SpendingService {
     @Transactional
     public Long createSpending(LocalDateTime date, long amount, String memo, boolean excludeTotal, String categoryName, String userId) {
         User user = userService.getUserById(userId);
-        Category category = categoryService.getCategoryByName(categoryName);
+        Category category = categoryService.getCategory(categoryName);
 
         Spending spending = spendingRepository.save(Spending.createSpending(date, amount, memo, excludeTotal, user, category));
         return spending.getId();
@@ -41,7 +41,7 @@ public class SpendingService {
         Long spendingId, LocalDateTime date, long amount, String memo, boolean excludeTotal, String categoryName, String userId
     ) {
         User user = userService.getUserById(userId);
-        Category category = categoryService.getCategoryByName(categoryName);
+        Category category = categoryService.getCategory(categoryName);
 
         Spending spending = getSpending(spendingId, user);
         spending.updateSpending(date, amount, memo, excludeTotal, category);

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -43,29 +43,40 @@ public class SpendingService {
         return GetSpendingDto.from(spending);
     }
 
-    public List<GetSpendingDto> getSpendingList(LocalDate startDate, LocalDate endDate, List<String> category, Long minAmount, Long maxAmount) {
+    public List<GetSpendingDto> getSpendingList(
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> category,
+        Long minAmount,
+        Long maxAmount,
+        String userId
+    ) {
+        User user = userService.getUserById(userId);
+
         LocalDateTime startDateTime = getStartDateTime(startDate);
         LocalDateTime endDateTime = getEndDateTime(endDate);
 
-        return spendingRepository.findByDateBetweenOrderByDateDesc(startDateTime, endDateTime).stream()
+        return spendingRepository.findByDateBetweenOrderByDateDesc(startDateTime, endDateTime, user).stream()
             .map(GetSpendingDto::from)
             .toList();
     }
 
-    public List<GetSpendingSummaryDto> getSumOfAmountByCategory(LocalDate startDate, LocalDate endDate) {
+    public List<GetSpendingSummaryDto> getSumOfAmountByCategory(LocalDate startDate, LocalDate endDate, String userId) {
         LocalDateTime startDateTime = getStartDateTime(startDate);
         LocalDateTime endDateTime = getEndDateTime(endDate);
 
-        return spendingRepository.getSumOfAmountByCategory(startDateTime, endDateTime).stream()
+        return spendingRepository.getSumOfAmountByCategory(startDateTime, endDateTime, userId).stream()
             .map(projection -> GetSpendingSummaryDto.of(projection.getCategoryName(), projection.getAmount()))
             .toList();
     }
 
-    public long getSumOfAmountByDate(LocalDate startDate, LocalDate endDate) {
+    public long getSumOfAmountByDate(LocalDate startDate, LocalDate endDate, String userId) {
+        User user = userService.getUserById(userId);
+
         LocalDateTime startDateTime = getStartDateTime(startDate);
         LocalDateTime endDateTime = getEndDateTime(endDate);
 
-        return spendingRepository.getSumOfAmountByDate(startDateTime, endDateTime);
+        return spendingRepository.getSumOfAmountByDate(startDateTime, endDateTime, user);
     }
 
     @Transactional

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -8,9 +8,13 @@ import com.wealdy.saemsembackend.domain.core.exception.NotFoundException;
 import com.wealdy.saemsembackend.domain.spending.entity.Spending;
 import com.wealdy.saemsembackend.domain.spending.repository.SpendingRepository;
 import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingDto;
+import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingSummaryDto;
 import com.wealdy.saemsembackend.domain.user.entity.User;
 import com.wealdy.saemsembackend.domain.user.repository.UserRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +28,7 @@ public class SpendingService {
     private final UserRepository userRepository;
 
     @Transactional
-    public Long createSpending(LocalDateTime date, int amount, String memo, boolean excludeTotal, String categoryName, String userId) {
+    public Long createSpending(LocalDateTime date, long amount, String memo, boolean excludeTotal, String categoryName, String userId) {
         User user = userRepository.findById(userId).get(0);
         Category category = categoryService.findByName(categoryName);
 
@@ -37,9 +41,42 @@ public class SpendingService {
         return GetSpendingDto.from(spending);
     }
 
+    public List<GetSpendingDto> getSpendingList(LocalDate startDate, LocalDate endDate, List<String> category, Long minAmount, Long maxAmount) {
+        LocalDateTime startDateTime = getStartDateTime(startDate);
+        LocalDateTime endDateTime = getEndDateTime(endDate);
+
+        return spendingRepository.findByDateBetweenOrderByDateDesc(startDateTime, endDateTime).stream()
+            .map(GetSpendingDto::from)
+            .toList();
+    }
+
+    public List<GetSpendingSummaryDto> getSumOfAmountByCategory(LocalDate startDate, LocalDate endDate) {
+        LocalDateTime startDateTime = getStartDateTime(startDate);
+        LocalDateTime endDateTime = getEndDateTime(endDate);
+
+        return spendingRepository.getSumOfAmountByCategory(startDateTime, endDateTime).stream()
+            .map(projection -> GetSpendingSummaryDto.of(projection.getCategoryName(), projection.getAmount()))
+            .toList();
+    }
+
+    public long getSumOfAmountByDate(LocalDate startDate, LocalDate endDate) {
+        LocalDateTime startDateTime = getStartDateTime(startDate);
+        LocalDateTime endDateTime = getEndDateTime(endDate);
+
+        return spendingRepository.getSumOfAmountByDate(startDateTime, endDateTime);
+    }
+
     @Transactional
     public void deleteSpending(Long spendingId) {
         Spending spending = spendingRepository.findById(spendingId).orElseThrow(() -> new NotFoundException(NOT_FOUND_SPENDING));
         spendingRepository.delete(spending);
+    }
+
+    private LocalDateTime getStartDateTime(LocalDate startDate) {
+        return LocalDate.parse(startDate.toString()).atStartOfDay();
+    }
+
+    private LocalDateTime getEndDateTime(LocalDate endDate) {
+        return endDate.atTime(LocalTime.MAX).withNano(0);
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -36,10 +36,20 @@ public class SpendingService {
         return spending.getId();
     }
 
+    @Transactional
+    public void updateSpending(
+        Long spendingId, LocalDateTime date, long amount, String memo, boolean excludeTotal, String categoryName, String userId
+    ) {
+        User user = userService.getUserById(userId);
+        Category category = categoryService.getCategoryByName(categoryName);
+
+        Spending spending = getSpending(spendingId, user);
+        spending.updateSpending(date, amount, memo, excludeTotal, category);
+    }
+
     public GetSpendingDto getSpending(Long spendingId, String userId) {
         User user = userService.getUserById(userId);
-        Spending spending = spendingRepository.findByIdAndUser(spendingId, user)
-            .orElseThrow(() -> new NotFoundException(NOT_FOUND_SPENDING));
+        Spending spending = getSpending(spendingId, user);
         return GetSpendingDto.from(spending);
     }
 
@@ -98,9 +108,13 @@ public class SpendingService {
     @Transactional
     public void deleteSpending(Long spendingId, String userId) {
         User user = userService.getUserById(userId);
-        Spending spending = spendingRepository.findByIdAndUser(spendingId, user)
-            .orElseThrow(() -> new NotFoundException(NOT_FOUND_SPENDING));
+        Spending spending = getSpending(spendingId, user);
         spendingRepository.delete(spending);
+    }
+
+    private Spending getSpending(Long spendingId, User user) {
+        return spendingRepository.findByIdAndUser(spendingId, user)
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_SPENDING));
     }
 
     private LocalDateTime getStartDateTime(LocalDate startDate) {

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingDto.java
@@ -11,12 +11,12 @@ import lombok.Getter;
 @Getter
 public class GetSpendingDto {
 
-    private Long id;
-    private String categoryName;
-    private LocalDateTime date;
-    private long amount;
-    private String memo;
-    private YnColumn excludeTotal;
+    private final Long id;
+    private final String categoryName;
+    private final LocalDateTime date;
+    private final long amount;
+    private final String memo;
+    private final YnColumn excludeTotal;
 
     public static GetSpendingDto from(Spending spending) {
         return new GetSpendingDto(

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingDto.java
@@ -14,7 +14,7 @@ public class GetSpendingDto {
     private Long id;
     private String categoryName;
     private LocalDateTime date;
-    private int amount;
+    private long amount;
     private String memo;
     private YnColumn excludeTotal;
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingSummaryDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingSummaryDto.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @Getter
 public class GetSpendingSummaryDto {
 
-    private String categoryName;
-    private long amount;
+    private final String categoryName;
+    private final long amount;
 
     public static GetSpendingSummaryDto of(String categoryName, long amount) {
         return new GetSpendingSummaryDto(categoryName, amount);

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingSummaryDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingSummaryDto.java
@@ -1,0 +1,17 @@
+package com.wealdy.saemsembackend.domain.spending.service.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class GetSpendingSummaryDto {
+
+    private String categoryName;
+    private long amount;
+
+    public static GetSpendingSummaryDto of(String categoryName, long amount) {
+        return new GetSpendingSummaryDto(categoryName, amount);
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/controller/response/LoginResponse.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/controller/response/LoginResponse.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LoginResponse {
 
-    private String accessToken;
+    private final String accessToken;
 
     public static LoginResponse from(GetLoginDto getLoginDto) {
         return new LoginResponse(getLoginDto.getAccessToken());

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/entity/User.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/entity/User.java
@@ -40,7 +40,7 @@ public class User {
     @ColumnDefault("'N'")
     @Column(nullable = false, length = 1)
     @Enumerated(EnumType.STRING)
-    private YnColumn isDeleted;  // 삭제 여부
+    private YnColumn deletedYn;  // 삭제 여부
 
     @CreationTimestamp
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/entity/User.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/entity/User.java
@@ -8,8 +8,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,10 +18,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(uniqueConstraints = {
-    @UniqueConstraint(name = "unique_user_login_id", columnNames = {"loginId"}),
-    @UniqueConstraint(name = "unique_user_nickname", columnNames = {"nickname"})
-})
 @Entity
 public class User {
 
@@ -32,16 +26,15 @@ public class User {
     @Column(name = "user_id")
     private Long id;  // 사용자 id
 
-    @Column(length = 20, nullable = false)
+    @Column(length = 20, nullable = false, unique = true)
     private String loginId;  // 아이디
 
     @Column(length = 60, nullable = false)
     private String password;  // 비밀번호
 
-    @Column(length = 15, nullable = false)
+    @Column(length = 15, nullable = false, unique = true)
     private String nickname;  // 닉네임
 
-    //    @Column(columnDefinition = "varchar(1) default 'N'", nullable = false)
     @ColumnDefault("'N'")
     @Column(nullable = false, length = 1)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/entity/User.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/entity/User.java
@@ -42,7 +42,7 @@ public class User {
     private String nickname;  // 닉네임
 
     //    @Column(columnDefinition = "varchar(1) default 'N'", nullable = false)
-    @ColumnDefault("N")
+    @ColumnDefault("'N'")
     @Column(nullable = false, length = 1)
     @Enumerated(EnumType.STRING)
     private YnColumn isDeleted;  // 삭제 여부

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/entity/User.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/entity/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
@@ -18,6 +19,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 public class User {
 
@@ -44,15 +46,6 @@ public class User {
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     @Column(nullable = false)
     private LocalDateTime createdAt;  // 생성일시
-
-    private User(Long id, String loginId, String password, String nickname, YnColumn isDeleted, LocalDateTime createdAt) {
-        this.id = id;
-        this.loginId = loginId;
-        this.password = password;
-        this.nickname = nickname;
-        this.isDeleted = isDeleted;
-        this.createdAt = createdAt;
-    }
 
     public static User createUser(String loginId, String password, String nickname) {
         return new User(null, loginId, password, nickname, YnColumn.N, null);

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/repository/UserRepository.java
@@ -2,7 +2,9 @@ package com.wealdy.saemsembackend.domain.user.repository;
 
 import com.wealdy.saemsembackend.domain.user.entity.User;
 import jakarta.persistence.EntityManager;
-import java.util.List;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -16,28 +18,44 @@ public class UserRepository {
         em.persist(user);
     }
 
-    public List<User> findById(String id) {
-        return em.createQuery("select u from User u where u.id = :id", User.class)
-            .setParameter("id", id)
-            .getResultList();
+    public Optional<User> findById(String id) {
+        TypedQuery<User> query = em.createQuery("select u from User u where u.id = :id", User.class)
+            .setParameter("id", id);
+        try {
+            return Optional.ofNullable(query.getSingleResult());
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
     }
 
-    public List<User> findByLoginId(String id) {
-        return em.createQuery("select u from User u where u.loginId = :id", User.class)
-            .setParameter("id", id)
-            .getResultList();
+    public Optional<User> findByLoginId(String id) {
+        TypedQuery<User> query = em.createQuery("select u from User u where u.loginId = :id", User.class)
+            .setParameter("id", id);
+        try {
+            return Optional.ofNullable(query.getSingleResult());
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
     }
 
-    public List<User> findByNickname(String nickname) {
-        return em.createQuery("select u from User u where u.nickname = :nickname", User.class)
-            .setParameter("nickname", nickname)
-            .getResultList();
+    public Optional<User> findByNickname(String nickname) {
+        TypedQuery<User> query = em.createQuery("select u from User u where u.nickname = :nickname", User.class)
+            .setParameter("nickname", nickname);
+        try {
+            return Optional.ofNullable(query.getSingleResult());
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
     }
 
-    public List<User> findByLoginIdAndPassword(String id, String password) {
-        return em.createQuery("select u from User u where u.loginId = :id and u.password = :password", User.class)
+    public Optional<User> findByLoginIdAndPassword(String id, String password) {
+        TypedQuery<User> query = em.createQuery("select u from User u where u.loginId = :id and u.password = :password", User.class)
             .setParameter("id", id)
-            .setParameter("password", password)
-            .getResultList();
+            .setParameter("password", password);
+        try {
+            return Optional.ofNullable(query.getSingleResult());
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
@@ -41,8 +41,8 @@ public class UserService {
     }
 
     @Transactional
-    public GetLoginDto login(String id, String password) {
-        User user = userRepository.findByLoginIdAndPassword(id, password)
+    public GetLoginDto login(String loginId, String password) {
+        User user = userRepository.findByLoginIdAndPassword(loginId, password)
             .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND_USER));
 
         Long userId = user.getId();

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
@@ -44,8 +44,8 @@ public class UserService {
         User user = userRepository.findByLoginIdAndPassword(id, password)
             .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND_USER));
 
-        JwtUtil jwtUtil = new JwtUtil();
         Long userId = user.getId();
+        JwtUtil jwtUtil = JwtUtil.getInstance();
         String accessToken = jwtUtil.createAccessToken(userId);
         return new GetLoginDto(accessToken);
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
@@ -40,6 +40,7 @@ public class UserService {
         }
     }
 
+    @Transactional
     public GetLoginDto login(String id, String password) {
         User user = userRepository.findByLoginIdAndPassword(id, password)
             .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND_USER));
@@ -50,6 +51,7 @@ public class UserService {
         return new GetLoginDto(accessToken);
     }
 
+    @Transactional(readOnly = true)
     public User getUserById(String userId) {
         return userRepository.findById(userId)
             .orElseThrow(() -> new NotFoundException(NOT_FOUND_USER));

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/service/dto/GetLoginDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/service/dto/GetLoginDto.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class GetLoginDto {
 
-    private String accessToken;
+    private final String accessToken;
 }


### PR DESCRIPTION
## 내용
1. 지출 목록 조회, 수정, 삭제 API
2. 예산 목록 조회 API
3. 코드 리뷰 수정 중

## 질문
1. 지출 목록 조회 중
SpendingRepository 의 getSumOfAmountByCategory 쿼리 한번 검토해 주시면 감사하겠습니다,,
제가 넘 복잡하게 한 것 같기도 해서요.
2. nativeQuery 를 쓰면 결국에 이 쿼리도 DB 종속적인 것 아닌가요?
3. JwtUtil 을 싱글톤으로 변경하였습니다. 근데 JwtUtil 내의 메소드들을 static 으로 변경하여 사용하는 것과 무슨 차이가 있나요?

## 알게 된 점
JPQL alias 가 적용되지 않음 -> Projection 사용하였더니 alias 에 맞게 잘 mapping 되었다.