### PR TITLE
예산 및 지출 추천 API, 오늘 지출 안내 API, 코드 리뷰 반영

### DIFF
--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
@@ -4,11 +4,13 @@ import static com.wealdy.saemsembackend.domain.core.Constant.LOGIN_ID_KEY;
 
 import com.wealdy.saemsembackend.domain.budget.controller.request.CreateBudgetRequest;
 import com.wealdy.saemsembackend.domain.budget.controller.response.BudgetListResponse;
+import com.wealdy.saemsembackend.domain.budget.controller.response.BudgetRecommendResponse;
 import com.wealdy.saemsembackend.domain.budget.service.BudgetService;
 import com.wealdy.saemsembackend.domain.core.response.Response;
 import com.wealdy.saemsembackend.domain.core.util.DateUtils;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
@@ -43,5 +45,16 @@ public class BudgetController {
     ) {
         LocalDate localDate = DateUtils.convertFirstDayOfMonth(year, month);
         return Response.of(BudgetListResponse.of(localDate, budgetService.getBudgetList(localDate, loginId)));
+    }
+
+    @GetMapping("/recommend")
+    public Response<BudgetRecommendResponse> recommendBudget(
+        @RequestParam @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.") long budgetTotal,
+        @RequestParam @Positive(message = "년도는 0 이상으로 입력해야 합니다.") int year,
+        @RequestParam @Range(min = 1, max = 12, message = "월은 1~12 범위 내에서 입력해야 합니다.") int month,
+        @RequestAttribute(name = LOGIN_ID_KEY) String loginId
+    ) {
+        LocalDate localDate = DateUtils.convertFirstDayOfMonth(year, month);
+        return Response.of(BudgetRecommendResponse.of(localDate, budgetTotal, budgetService.recommendBudget(budgetTotal, localDate, loginId)));
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/BudgetController.java
@@ -31,12 +31,18 @@ public class BudgetController {
 
     private final BudgetService budgetService;
 
+    /**
+     * 예산 설정 API
+     */
     @PostMapping
     public Response<Void> createBudget(@Valid @RequestBody CreateBudgetRequest request, @RequestAttribute(name = LOGIN_ID_KEY) String loginId) {
         budgetService.createBudget(DateUtils.convertFirstDayOfMonth(request.getYear(), request.getMonth()), request.getBudgets(), loginId);
         return Response.OK;
     }
 
+    /**
+     * 예산 목록 조회 API
+     */
     @GetMapping
     public Response<BudgetListResponse> getBudgetList(
         @RequestParam @Positive(message = "년도는 0 이상으로 입력해야 합니다.") int year,
@@ -47,6 +53,9 @@ public class BudgetController {
         return Response.of(BudgetListResponse.of(localDate, budgetService.getBudgetList(localDate, loginId)));
     }
 
+    /**
+     * 예산 설계 (추천) API
+     */
     @GetMapping("/recommend")
     public Response<BudgetRecommendResponse> recommendBudget(
         @RequestParam @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.") long budgetTotal,

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/response/BudgetRecommendResponse.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/controller/response/BudgetRecommendResponse.java
@@ -1,0 +1,21 @@
+package com.wealdy.saemsembackend.domain.budget.controller.response;
+
+import com.wealdy.saemsembackend.domain.budget.service.dto.GetBudgetDto;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class BudgetRecommendResponse {
+
+    private final LocalDate date;
+    private final long budgetTotal;
+    private final List<GetBudgetDto> budgets;
+
+    public static BudgetRecommendResponse of(LocalDate date, long budgetTotal, List<GetBudgetDto> budgets) {
+        return new BudgetRecommendResponse(date, budgetTotal, budgets);
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/entity/Budget.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/entity/Budget.java
@@ -12,9 +12,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -53,6 +55,16 @@ public class Budget {
     // 생성 메서드
     public static Budget createBudget(LocalDate date, long amount, User user, Category category) {
         return new Budget(
+            date,
+            amount,
+            user,
+            category
+        );
+    }
+
+    public static Budget of(Long id, LocalDate date, long amount, User user, Category category) {
+        return new Budget(
+            id,
             date,
             amount,
             user,

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/BudgetRepository.java
@@ -22,4 +22,6 @@ public interface BudgetRepository {
     List<BudgetRecommendProjection> findByDate(@Param("date") LocalDate date);
 
     List<BudgetTotalProjection> sumByUser(@Param("date") LocalDate date);
+
+    Long findAmountByUserAndCategory(LocalDate date, User user, String categoryId);
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/BudgetRepository.java
@@ -1,7 +1,9 @@
 package com.wealdy.saemsembackend.domain.budget.repository;
 
 import com.wealdy.saemsembackend.domain.budget.entity.Budget;
+import com.wealdy.saemsembackend.domain.budget.repository.projection.BudgetRecommendProjection;
 import com.wealdy.saemsembackend.domain.budget.repository.projection.BudgetSummaryProjection;
+import com.wealdy.saemsembackend.domain.budget.repository.projection.BudgetTotalProjection;
 import com.wealdy.saemsembackend.domain.category.entity.Category;
 import com.wealdy.saemsembackend.domain.user.entity.User;
 import java.time.LocalDate;
@@ -18,4 +20,12 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
     @Query(value = "select c.name as categoryName, coalesce(b.amount, 0) as amount from Category c "
         + "left join Budget b on c.id = b.category.id and b.date = :date and b.user = :user")
     List<BudgetSummaryProjection> findByDateAndUser(@Param("date") LocalDate date, @Param("user") User user);
+
+    @Query(value = "select b.user.id as userId, c.name as categoryName, b.amount as amount from Category c "
+        + "left join Budget b on c.id = b.category.id and b.date = :date")
+    List<BudgetRecommendProjection> findByDate(@Param("date") LocalDate date);
+
+    @Query(value = "select b.user.id as userId, sum(b.amount) as sumOfBudget from Budget b "
+        + "where b.date = :date group by b.user")
+    List<BudgetTotalProjection> sumByUser(@Param("date") LocalDate date);
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/DefaultBudgetRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/DefaultBudgetRepository.java
@@ -1,0 +1,45 @@
+package com.wealdy.saemsembackend.domain.budget.repository;
+
+import com.wealdy.saemsembackend.domain.budget.entity.Budget;
+import com.wealdy.saemsembackend.domain.budget.repository.projection.BudgetRecommendProjection;
+import com.wealdy.saemsembackend.domain.budget.repository.projection.BudgetSummaryProjection;
+import com.wealdy.saemsembackend.domain.budget.repository.projection.BudgetTotalProjection;
+import com.wealdy.saemsembackend.domain.category.entity.Category;
+import com.wealdy.saemsembackend.domain.user.entity.User;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DefaultBudgetRepository implements BudgetRepository {
+
+    private final JpaBudgetRepository jpaBudgetRepository;
+
+    @Override
+    public Budget save(Budget budget) {
+        return jpaBudgetRepository.save(budget);
+    }
+
+    @Override
+    public Optional<Budget> findByDateAndCategoryAndUser(LocalDate date, Category category, User user) {
+        return jpaBudgetRepository.findByDateAndCategoryAndUser(date, category, user);
+    }
+
+    @Override
+    public List<BudgetSummaryProjection> findByDateAndUser(LocalDate date, User user) {
+        return jpaBudgetRepository.findByDateAndUser(date, user);
+    }
+
+    @Override
+    public List<BudgetRecommendProjection> findByDate(LocalDate date) {
+        return jpaBudgetRepository.findByDate(date);
+    }
+
+    @Override
+    public List<BudgetTotalProjection> sumByUser(LocalDate date) {
+        return jpaBudgetRepository.sumByUser(date);
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/DefaultBudgetRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/DefaultBudgetRepository.java
@@ -42,4 +42,9 @@ public class DefaultBudgetRepository implements BudgetRepository {
     public List<BudgetTotalProjection> sumByUser(LocalDate date) {
         return jpaBudgetRepository.sumByUser(date);
     }
+
+    @Override
+    public Long findAmountByUserAndCategory(LocalDate date, User user, String categoryId) {
+        return jpaBudgetRepository.findAmountByUserAndCategory(date, user, categoryId);
+    }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/JpaBudgetRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/JpaBudgetRepository.java
@@ -28,4 +28,7 @@ public interface JpaBudgetRepository extends JpaRepository<Budget, Long> {
     @Query(value = "select b.user.id as userId, sum(b.amount) as sumOfBudget from Budget b "
         + "where b.date = :date group by b.user")
     List<BudgetTotalProjection> sumByUser(@Param("date") LocalDate date);
+
+    @Query(value = "select b.amount from Budget b where b.date = :date and b.user = :user and b.category.name = :category")
+    Long findAmountByUserAndCategory(@Param("date") LocalDate date, @Param("user") User user, @Param("category") String category);
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/JpaBudgetRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/JpaBudgetRepository.java
@@ -9,17 +9,23 @@ import com.wealdy.saemsembackend.domain.user.entity.User;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface BudgetRepository {
-
-    Budget save(Budget budget);
+public interface JpaBudgetRepository extends JpaRepository<Budget, Long> {
 
     Optional<Budget> findByDateAndCategoryAndUser(LocalDate date, Category category, User user);
 
+    @Query(value = "select c.name as categoryName, coalesce(b.amount, 0) as amount from Category c "
+        + "left join Budget b on c.id = b.category.id and b.date = :date and b.user = :user")
     List<BudgetSummaryProjection> findByDateAndUser(@Param("date") LocalDate date, @Param("user") User user);
 
+    @Query(value = "select b.user.id as userId, c.name as categoryName, b.amount as amount from Category c "
+        + "left join Budget b on c.id = b.category.id and b.date = :date")
     List<BudgetRecommendProjection> findByDate(@Param("date") LocalDate date);
 
+    @Query(value = "select b.user.id as userId, sum(b.amount) as sumOfBudget from Budget b "
+        + "where b.date = :date group by b.user")
     List<BudgetTotalProjection> sumByUser(@Param("date") LocalDate date);
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/projection/BudgetRecommendProjection.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/projection/BudgetRecommendProjection.java
@@ -1,0 +1,10 @@
+package com.wealdy.saemsembackend.domain.budget.repository.projection;
+
+public interface BudgetRecommendProjection {
+
+    Long getUserId();
+
+    String getCategoryName();
+
+    Long getAmount();
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/projection/BudgetTotalProjection.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/repository/projection/BudgetTotalProjection.java
@@ -1,0 +1,8 @@
+package com.wealdy.saemsembackend.domain.budget.repository.projection;
+
+public interface BudgetTotalProjection {
+
+    Long getUserId();
+
+    Long getSumOfBudget();
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -29,28 +29,17 @@ public class BudgetService {
             .forEach(getBudgetDto -> {
                 User user = userService.getUser(loginId);
                 Category category = categoryService.getCategory(getBudgetDto.getCategoryName());
-                Optional<Budget> findBudget = findBudget(date, user, category);
-                createBudget(date, getBudgetDto, user, category, findBudget);
+                Optional<Budget> findBudget = budgetRepository.findByDateAndCategoryAndUser(date, category, user);
+                findBudget.ifPresentOrElse(
+                    budget -> budget.updateBudget(getBudgetDto.getAmount()),
+                    () -> createBudget(date, getBudgetDto, user, category)
+                );
             });
     }
 
-    private void createBudget(LocalDate date, BudgetSummaryDto getBudgetDto, User user, Category category, Optional<Budget> findBudget) {
-        findBudget.ifPresentOrElse(
-            budget -> budget.updateBudget(getBudgetDto.getAmount()),
-            () -> {
-                Budget budget = Budget.createBudget(
-                    date,
-                    getBudgetDto.getAmount(),
-                    user,
-                    category
-                );
-                budgetRepository.save(budget);
-            }
-        );
-    }
-
-    private Optional<Budget> findBudget(LocalDate date, User user, Category category) {
-        return budgetRepository.findByDateAndCategoryAndUser(date, category, user);
+    private void createBudget(LocalDate date, BudgetSummaryDto getBudgetDto, User user, Category category) {
+        Budget budget = Budget.createBudget(date, getBudgetDto.getAmount(), user, category);
+        budgetRepository.save(budget);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -2,6 +2,7 @@ package com.wealdy.saemsembackend.domain.budget.service;
 
 import com.wealdy.saemsembackend.domain.budget.entity.Budget;
 import com.wealdy.saemsembackend.domain.budget.repository.BudgetRepository;
+import com.wealdy.saemsembackend.domain.budget.repository.projection.BudgetRecommendProjection;
 import com.wealdy.saemsembackend.domain.budget.service.dto.BudgetSummaryDto;
 import com.wealdy.saemsembackend.domain.budget.service.dto.GetBudgetDto;
 import com.wealdy.saemsembackend.domain.category.entity.Category;
@@ -9,7 +10,10 @@ import com.wealdy.saemsembackend.domain.category.service.CategoryService;
 import com.wealdy.saemsembackend.domain.user.entity.User;
 import com.wealdy.saemsembackend.domain.user.service.UserService;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -48,5 +52,88 @@ public class BudgetService {
         return budgetRepository.findByDateAndUser(date, user).stream()
             .map(projection -> GetBudgetDto.of(projection.getCategoryName(), projection.getAmount()))
             .toList();
+    }
+
+    /*
+        예산 추천
+
+        1. 유저 별 예산 총합을 조회합니다. / 카테고리 별 유저 들의 예산 목록을 조회합니다.
+        2. 카테고리 별로 유저들이 설정한 예산 비율을 구합니다.
+        3. 카테고리 별 예산의 평균 비율을 구합니다.
+          - 평균 비율 구하고 반올림 하면 카테고리들의 비율 총합이 항상 100%로 유지됩니다.
+        4. 평균 비율이 10% 이하인 카테고리는 기타 비율에 추가합니다.
+        5. 비율에 맞는 추천 금액을 계산합니다.
+          - 추천 금액은 소수점일 수 없으므로 반올림합니다.
+        6. 오차는 (최대 1원) 기타 카테고리에 반영합니다.
+          - 기타 카테고리가 예산 추천 리스트의 가장 마지막에 추가되므로..
+     */
+    @Transactional(readOnly = true)
+    public List<GetBudgetDto> recommendBudget(long budgetTotal, LocalDate date, String loginId) {
+        userService.getUser(loginId);
+
+        int MAX_RATIO = 10;  // 기타에 포함될 최대 비율
+        List<GetBudgetDto> budgetDtoList = new ArrayList<>();
+
+        Map<Long, Long> sumOfBudgetByUserMap = new HashMap<>();  // 유저별 예산 총합
+        budgetRepository.sumByUser(date).forEach(projection -> sumOfBudgetByUserMap.put(projection.getUserId(), projection.getSumOfBudget()));
+        int userCnt = sumOfBudgetByUserMap.size();  // user 수
+
+        long recommendAmountTotal = 0;  // 추천 예산의 총 합
+        int countForCategory = 0;  // 현재 카테고리로 설정된 예산 개수 카운트
+        double ratioSum = 0;  // 카테고리 별 예산 비율 합계
+        long etcRatioSum = 0;  // 기타로 제공 될 카테고리 비율의 합
+
+        // 카테고리 별 유저들의 예산 목록
+        List<BudgetRecommendProjection> budgetList = budgetRepository.findByDate(date);
+        for (BudgetRecommendProjection budget : budgetList) {
+            countForCategory++;
+
+            String categoryName = budget.getCategoryName();
+
+            // 카테고리 별 유저들이 설정한 예산 비율
+            double categoryAmount = budget.getAmount();
+            double totalAmount = sumOfBudgetByUserMap.get(budget.getUserId());
+            double ratio = (categoryAmount / totalAmount) * 100.0;
+            ratioSum += ratio;
+
+            // 해당 카테고리의 예산이 아직 존재하면 계속 확인
+            if (countForCategory != userCnt) {
+                continue;
+            }
+
+            // 해당 카테고리의 예산을 모두 확인했다면
+            // 평균 비율 및 추천 금액 계산
+            long avgRatio = Math.round(ratioSum / (double) userCnt);
+            double amount = budgetTotal * avgRatio / 100.0;
+            long recommendAmount = Math.round(amount);
+
+            // 10% 미만인 카테고리의 비율 또는 기타 카테고리 비율
+            if (avgRatio < MAX_RATIO || categoryName.equals("기타")) {
+                etcRatioSum += avgRatio;  // 기타로 제공 될 카테고리 비율을 합하기
+                recommendAmount = 0;
+            }
+            recommendAmountTotal += recommendAmount;
+
+            // 기타를 제외한 카테고리는 예산 추천 객체 생성
+            if (!categoryName.equals("기타")) {
+                budgetDtoList.add(GetBudgetDto.of(categoryName, recommendAmount));
+            }
+
+            // 다음 카테고리 통계를 위한 초기화
+            countForCategory = 0;
+            ratioSum = 0;
+        }
+
+        // 기타 카테고리는 모든 카테고리의 통계 계산이 끝난 후 예산 추천 객체 생성
+        long etcRecommendAmount = Math.round(budgetTotal * etcRatioSum / 100.0);
+        // 추천 예산의 총 합에 기타 카테고리 합하기
+        recommendAmountTotal += etcRecommendAmount;
+        // 오차는 기타 카테고리에 반영
+        etcRecommendAmount += budgetTotal - recommendAmountTotal;
+
+        // 기타 카테고리 예산 추천 객체 생성
+        budgetDtoList.add(GetBudgetDto.of("기타", etcRecommendAmount));
+
+        return budgetDtoList;
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/BudgetService.java
@@ -27,6 +27,7 @@ public class BudgetService {
     private final CategoryService categoryService;
     private final UserService userService;
 
+    // 예산 설정
     @Transactional
     public void createBudget(LocalDate date, List<BudgetSummaryDto> getBudgetDtoList, String loginId) {
         getBudgetDtoList
@@ -46,6 +47,7 @@ public class BudgetService {
         budgetRepository.save(budget);
     }
 
+    // 예산 목록 조회
     @Transactional(readOnly = true)
     public List<GetBudgetDto> getBudgetList(LocalDate date, String loginId) {
         User user = userService.getUser(loginId);

--- a/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/GetBudgetDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/budget/service/dto/GetBudgetDto.java
@@ -1,7 +1,5 @@
 package com.wealdy.saemsembackend.domain.budget.service.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,10 +8,7 @@ import lombok.Getter;
 @Getter
 public class GetBudgetDto {
 
-    @NotBlank(message = "카테고리는 필수 값입니다.")
     private final String categoryName;
-
-    @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.")
     private final long amount;
 
     public static GetBudgetDto of(String categoryName, long amount) {

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/entity/Category.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/entity/Category.java
@@ -5,8 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 public class Category {
@@ -18,4 +23,8 @@ public class Category {
 
     @Column(length = 30, nullable = false, unique = true)
     private String name;  // 카테고리명
+
+    public static Category of(Long id, String name) {
+        return new Category(id, name);
+    }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/repository/CategoryRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 public interface CategoryRepository {
 
+    void save(Category category);
+
     List<Category> findAll();
 
     Optional<Category> findByName(String name);

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/repository/CategoryRepository.java
@@ -1,35 +1,12 @@
 package com.wealdy.saemsembackend.domain.category.repository;
 
 import com.wealdy.saemsembackend.domain.category.entity.Category;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.NoResultException;
-import jakarta.persistence.TypedQuery;
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
-@Repository
-@RequiredArgsConstructor
-public class CategoryRepository {
+public interface CategoryRepository {
 
-    private final EntityManager em;
+    List<Category> findAll();
 
-    public Long countAll() {
-        return em.createQuery("select count(c) from Category c", Long.class).getSingleResult();
-    }
-
-    public List<Category> findAll() {
-        return em.createQuery("select c from Category c", Category.class).getResultList();
-    }
-
-    public Optional<Category> findByName(String name) {
-        TypedQuery<Category> query = em.createQuery("select c from Category c where c.name=:name", Category.class)
-            .setParameter("name", name);
-        try {
-            return Optional.ofNullable(query.getSingleResult());
-        } catch (NoResultException e) {
-            return Optional.empty();
-        }
-    }
+    Optional<Category> findByName(String name);
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/repository/JpaCategoryRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/repository/JpaCategoryRepository.java
@@ -1,0 +1,31 @@
+package com.wealdy.saemsembackend.domain.category.repository;
+
+import com.wealdy.saemsembackend.domain.category.entity.Category;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaCategoryRepository implements CategoryRepository {
+
+    private final EntityManager em;
+
+    public List<Category> findAll() {
+        return em.createQuery("select c from Category c", Category.class).getResultList();
+    }
+
+    public Optional<Category> findByName(String name) {
+        TypedQuery<Category> query = em.createQuery("select c from Category c where c.name=:name", Category.class)
+            .setParameter("name", name);
+        try {
+            return Optional.ofNullable(query.getSingleResult());
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/category/repository/JpaCategoryRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/category/repository/JpaCategoryRepository.java
@@ -15,6 +15,11 @@ public class JpaCategoryRepository implements CategoryRepository {
 
     private final EntityManager em;
 
+    @Override
+    public void save(Category category) {
+        em.persist(category);
+    }
+
     public List<Category> findAll() {
         return em.createQuery("select c from Category c", Category.class).getResultList();
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/enums/SpendingMessage.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/enums/SpendingMessage.java
@@ -1,0 +1,18 @@
+package com.wealdy.saemsembackend.domain.core.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum SpendingMessage {
+
+    SAVING_WELL("완벽한 절약 습관이네요 :) 오늘도 절약 도전!"),
+    MODERATE_USAGE("적당히 사용하고 계시네요 :> 계속 유지해봐요!"),
+    EXCEEDING_LIMIT("이대로 가다가는 예산이 부족해져요.. :< 절약하는 습관을 들여봐요~"),
+    OVERSPENT("예산 초과 :( 돈이 줄줄 새요!!!");
+
+    private final String message;
+
+    SpendingMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/exception/InvalidUserException.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/exception/InvalidUserException.java
@@ -1,0 +1,19 @@
+package com.wealdy.saemsembackend.domain.core.exception;
+
+import com.wealdy.saemsembackend.domain.core.response.ResponseCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class InvalidUserException extends ExceptionBase {
+
+    public InvalidUserException(ResponseCode responseCode) {
+        code = responseCode.getCode();
+        message = responseCode.getMessage();
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.UNAUTHORIZED.value();
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/exception/NotSetException.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/exception/NotSetException.java
@@ -1,0 +1,19 @@
+package com.wealdy.saemsembackend.domain.core.exception;
+
+import com.wealdy.saemsembackend.domain.core.response.ResponseCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class NotSetException extends ExceptionBase {
+
+    public NotSetException(ResponseCode responseCode) {
+        code = responseCode.getCode();
+        message = responseCode.getMessage();
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/response/ResponseCode.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/response/ResponseCode.java
@@ -17,13 +17,13 @@ public enum ResponseCode {
     // Http Status Code 401
     INVALID_TOKEN(3000, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(3001, "만료된 토큰입니다."),
+    INVALID_LOGIN_ID(3002, "존재하지 않는 아이디입니다."),
+    INVALID_PASSWORD(3003, "비밀번호가 틀립니다."),
 
     // Http Status Code 404
     NOT_FOUND_USER(4001, "존재하지 않는 회원입니다."),
     NOT_FOUND_CATEGORY(4002, "존재하지 않는 카테고리입니다."),
     NOT_FOUND_SPENDING(4003, "존재하지 않는 지출입니다."),
-    NOT_FOUND_LOGIN_ID(4004, "존재하지 않는 아이디입니다."),
-    NOT_FOUND_PASSWORD(4005, "비밀번호가 틀립니다."),
 
     // HTTP_CODE 500
     UNKNOWN_ERROR(-1, "Unknown Error");

--- a/src/main/java/com/wealdy/saemsembackend/domain/core/response/ResponseCode.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/core/response/ResponseCode.java
@@ -13,6 +13,7 @@ public enum ResponseCode {
     INVALID_PARAMETER(1000, "Invalid Parameter"),
     ALREADY_EXIST_ID(2000, "이미 존재하는 아이디입니다."),
     ALREADY_EXIST_NICKNAME(2001, "이미 존재하는 닉네임입니다."),
+    NOT_SET_BUDGET_FOR_SPENDING_RECOMMEND(2002, "지출 추천은 이달의 예산 설정 후에 가능합니다."),
 
     // Http Status Code 401
     INVALID_TOKEN(3000, "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -12,6 +12,7 @@ import com.wealdy.saemsembackend.domain.spending.controller.request.UpdateSpendi
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingListResponse;
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingResponse;
 import com.wealdy.saemsembackend.domain.spending.service.SpendingService;
+import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingListDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -62,7 +63,23 @@ public class SpendingController {
     }
 
     @GetMapping
-    public Response<SpendingListResponse> getSpendingList(
+    public Response<GetSpendingListDto> getSpendingList(
+        @RequestParam @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 'yyyy-MM-dd' 으로 입력해야 합니다.") String startDate,
+        @RequestParam @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 'yyyy-MM-dd' 으로 입력해야 합니다.") String endDate,
+        @RequestParam(required = false) List<String> category,
+        @RequestParam(required = false) @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.") Long minAmount,
+        @RequestParam(required = false) @PositiveOrZero(message = "금액은 0원 이상으로 입력해야 합니다.") Long maxAmount,
+        @RequestAttribute(name = LOGIN_ID_KEY) String loginId
+    ) {
+        LocalDate startLocalDate = LocalDate.parse(startDate);
+        LocalDate endLocalDate = LocalDate.parse(endDate);
+
+        return Response.of(spendingService.getSpendingList(startLocalDate, endLocalDate, category, minAmount, maxAmount, loginId));
+    }
+
+    // 쿼리로 모든 응답 값들을 조회
+    @GetMapping("/query")
+    public Response<SpendingListResponse> getSpendingListWithQuery(
         @RequestParam @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 'yyyy-MM-dd' 으로 입력해야 합니다.") String startDate,
         @RequestParam @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 'yyyy-MM-dd' 으로 입력해야 합니다.") String endDate,
         @RequestParam(required = false) List<String> category,
@@ -74,7 +91,7 @@ public class SpendingController {
         LocalDate endLocalDate = LocalDate.parse(endDate);
 
         ListResponseDto<SpendingResponse> spendingList = ListResponseDto.from(
-            spendingService.getSpendingList(startLocalDate, endLocalDate, category, minAmount, maxAmount, loginId).stream()
+            spendingService.getSpendingListWithQuery(startLocalDate, endLocalDate, category, minAmount, maxAmount, loginId).stream()
                 .map(SpendingResponse::from)
                 .toList());
         long sumOfAmount = spendingService.getSumOfAmountByDate(startLocalDate, endLocalDate, category, minAmount, maxAmount, loginId);

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -13,6 +13,7 @@ import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingLis
 import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingResponse;
 import com.wealdy.saemsembackend.domain.spending.service.SpendingService;
 import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingListDto;
+import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingRecommendDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -119,6 +120,11 @@ public class SpendingController {
         );
 
         return Response.of(IdResponseDto.from(spendingId));
+    }
+
+    @GetMapping("/recommend")
+    public Response<GetSpendingRecommendDto> recommendSpending(@RequestAttribute(name = LOGIN_ID_KEY) String loginId) {
+        return Response.of(spendingService.recommendSpending(loginId));
     }
 
     @PutMapping("/exclude/{spendingId}")

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -14,6 +14,7 @@ import com.wealdy.saemsembackend.domain.spending.controller.response.SpendingRes
 import com.wealdy.saemsembackend.domain.spending.service.SpendingService;
 import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingListDto;
 import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingRecommendDto;
+import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingTodayDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -125,6 +126,14 @@ public class SpendingController {
     @GetMapping("/recommend")
     public Response<GetSpendingRecommendDto> recommendSpending(@RequestAttribute(name = LOGIN_ID_KEY) String loginId) {
         return Response.of(spendingService.recommendSpending(loginId));
+    }
+
+    /*
+        오늘 지출 안내
+     */
+    @GetMapping("/today")
+    public Response<GetSpendingTodayDto> spendingToday(@RequestAttribute(name = LOGIN_ID_KEY) String loginId) {
+        return Response.of(spendingService.spendingToday(loginId));
     }
 
     @PutMapping("/exclude/{spendingId}")

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/SpendingController.java
@@ -42,6 +42,9 @@ public class SpendingController {
 
     private final SpendingService spendingService;
 
+    /**
+     * 지출 생성 API
+     */
     @PostMapping
     public Response<IdResponseDto> createSpending(
         @Valid @RequestBody CreateSpendingRequest request,
@@ -59,11 +62,18 @@ public class SpendingController {
         return Response.of(IdResponseDto.from(spendingId));
     }
 
+    /**
+     * 지출 상세 조회 API
+     */
     @GetMapping("/{spendingId}")
     public Response<SpendingResponse> getSpending(@PathVariable Long spendingId, @RequestAttribute(name = LOGIN_ID_KEY) String loginId) {
         return Response.of(SpendingResponse.from(spendingService.getSpending(spendingId, loginId)));
     }
 
+    /**
+     * 지출 목록 조회 API (with Java)
+     * java 로 처리 로직 구현
+     */
     @GetMapping
     public Response<GetSpendingListDto> getSpendingList(
         @RequestParam @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 'yyyy-MM-dd' 으로 입력해야 합니다.") String startDate,
@@ -79,7 +89,10 @@ public class SpendingController {
         return Response.of(spendingService.getSpendingList(startLocalDate, endLocalDate, category, minAmount, maxAmount, loginId));
     }
 
-    // 쿼리로 모든 응답 값들을 조회
+    /**
+     * 지출 목록 조회 API (with Query)
+     * 쿼리로 모든 응답 값들을 조회
+     */
     @GetMapping("/query")
     public Response<SpendingListResponse> getSpendingListWithQuery(
         @RequestParam @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 'yyyy-MM-dd' 으로 입력해야 합니다.") String startDate,
@@ -105,6 +118,9 @@ public class SpendingController {
         return Response.of(SpendingListResponse.of(sumOfAmount, sumOfAmountByCategory, spendingList));
     }
 
+    /**
+     * 지출 수정 API
+     */
     @PutMapping("/{spendingId}")
     public Response<IdResponseDto> update(
         @PathVariable Long spendingId,
@@ -123,19 +139,25 @@ public class SpendingController {
         return Response.of(IdResponseDto.from(spendingId));
     }
 
+    /**
+     * 오늘 지출 추천 API
+     */
     @GetMapping("/recommend")
     public Response<GetSpendingRecommendDto> recommendSpending(@RequestAttribute(name = LOGIN_ID_KEY) String loginId) {
         return Response.of(spendingService.recommendSpending(loginId));
     }
 
-    /*
-        오늘 지출 안내
+    /**
+     * 오늘 지출 안내 API
      */
     @GetMapping("/today")
     public Response<GetSpendingTodayDto> spendingToday(@RequestAttribute(name = LOGIN_ID_KEY) String loginId) {
         return Response.of(spendingService.spendingToday(loginId));
     }
 
+    /**
+     * 지출의 합계 제외 수정 API
+     */
     @PutMapping("/exclude/{spendingId}")
     public Response<IdResponseDto> updateExclude(
         @PathVariable Long spendingId,
@@ -147,6 +169,9 @@ public class SpendingController {
         return Response.of(IdResponseDto.from(spendingId));
     }
 
+    /**
+     * 지출 삭제 API
+     */
     @DeleteMapping("/{spendingId}")
     public Response<Void> deleteSpending(@PathVariable Long spendingId, @RequestAttribute(name = LOGIN_ID_KEY) String loginId) {
         spendingService.deleteSpending(spendingId, loginId);

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/response/SpendingListResponse.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/controller/response/SpendingListResponse.java
@@ -15,8 +15,9 @@ public class SpendingListResponse {
     private final List<SpendingSummaryDto> spendingTotalByCategory;
     private final ListResponseDto<SpendingResponse> spendingList;
 
-    public static SpendingListResponse of(long spendingTotal, List<SpendingSummaryDto> spendingTotalByCategory,
-        ListResponseDto<SpendingResponse> spendingList) {
+    public static SpendingListResponse of(
+        long spendingTotal, List<SpendingSummaryDto> spendingTotalByCategory, ListResponseDto<SpendingResponse> spendingList
+    ) {
         return new SpendingListResponse(spendingTotal, spendingTotalByCategory, spendingList);
     }
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
@@ -3,6 +3,7 @@ package com.wealdy.saemsembackend.domain.spending.repository;
 import com.wealdy.saemsembackend.domain.spending.entity.Spending;
 import com.wealdy.saemsembackend.domain.spending.repository.projection.SpendingRecommendProjection;
 import com.wealdy.saemsembackend.domain.spending.repository.projection.SpendingSummaryProjection;
+import com.wealdy.saemsembackend.domain.spending.repository.projection.SpendingTodayProjection;
 import com.wealdy.saemsembackend.domain.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -84,5 +85,17 @@ public interface SpendingRepository extends JpaRepository<Spending, Long>, JpaSp
         @Param("startDate") LocalDateTime startDate,
         @Param("endDate") LocalDateTime endDate,
         @Param("userId") Long userId
+    );
+
+    /*
+        카테고리별 금액 총합 조회 (날짜, user 로 조회)
+     */
+    @Query(value = "select c as category, coalesce(sum(s.amount), 0) as usedAmount from Category c "
+        + "left join Spending s on c = s.category and s.user = :user and s.date between :startDate and :endDate "
+        + "group by c")
+    List<SpendingTodayProjection> getSumAmountByCategoryAndDate(
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate,
+        @Param("user") User user
     );
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/SpendingRepository.java
@@ -1,6 +1,7 @@
 package com.wealdy.saemsembackend.domain.spending.repository;
 
 import com.wealdy.saemsembackend.domain.spending.entity.Spending;
+import com.wealdy.saemsembackend.domain.spending.repository.projection.SpendingRecommendProjection;
 import com.wealdy.saemsembackend.domain.spending.repository.projection.SpendingSummaryProjection;
 import com.wealdy.saemsembackend.domain.user.entity.User;
 import java.time.LocalDateTime;
@@ -65,6 +66,23 @@ public interface SpendingRepository extends JpaRepository<Spending, Long>, JpaSp
         @Param("category") List<String> category,
         @Param("minAmount") Long minAmount,
         @Param("maxAmount") Long maxAmount,
+        @Param("userId") Long userId
+    );
+
+    @Query(nativeQuery = true,
+        value = "select categoryName, sum(amount) as usedAmount "
+            + "from (select c.name as categoryName, sum(s.amount) as amount from spending s "
+            + "left join category c on c.category_id = s.category_id "
+            + "where s.date between :startDate and :endDate and s.user_id = :userId "
+            + "group by c.name "
+            + "union "
+            + "select c.name as categoryName, 0 as amount from spending s "
+            + "right join category c on c.category_id = s.category_id) "
+            + "as spendingByCategory group by categoryName"
+    )
+    List<SpendingRecommendProjection> getUsedAmountByCategory(
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate,
         @Param("userId") Long userId
     );
 }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/projection/SpendingRecommendProjection.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/projection/SpendingRecommendProjection.java
@@ -1,0 +1,8 @@
+package com.wealdy.saemsembackend.domain.spending.repository.projection;
+
+public interface SpendingRecommendProjection {
+
+    String getCategoryName();
+
+    Long getUsedAmount();
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/projection/SpendingTodayProjection.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/repository/projection/SpendingTodayProjection.java
@@ -1,0 +1,10 @@
+package com.wealdy.saemsembackend.domain.spending.repository.projection;
+
+import com.wealdy.saemsembackend.domain.category.entity.Category;
+
+public interface SpendingTodayProjection {
+
+    Category getCategory();
+
+    Long getUsedAmount();
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -4,17 +4,25 @@ import static com.wealdy.saemsembackend.domain.core.response.ResponseCode.NOT_FO
 
 import com.wealdy.saemsembackend.domain.category.entity.Category;
 import com.wealdy.saemsembackend.domain.category.service.CategoryService;
+import com.wealdy.saemsembackend.domain.category.service.dto.GetCategoryDto;
+import com.wealdy.saemsembackend.domain.core.enums.YnColumn;
 import com.wealdy.saemsembackend.domain.core.exception.NotFoundException;
+import com.wealdy.saemsembackend.domain.core.response.ListResponseDto;
 import com.wealdy.saemsembackend.domain.spending.entity.Spending;
 import com.wealdy.saemsembackend.domain.spending.repository.SpendingRepository;
 import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingDto;
+import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingListDto;
 import com.wealdy.saemsembackend.domain.spending.service.dto.GetSpendingSummaryDto;
 import com.wealdy.saemsembackend.domain.user.entity.User;
 import com.wealdy.saemsembackend.domain.user.service.UserService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,7 +70,54 @@ public class SpendingService {
     }
 
     @Transactional(readOnly = true)
-    public List<GetSpendingDto> getSpendingList(
+    public GetSpendingListDto getSpendingList(
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> category,
+        Long minAmount,
+        Long maxAmount,
+        String loginId
+    ) {
+        User user = userService.getUser(loginId);
+
+        LocalDateTime startDateTime = getStartDateTime(startDate);
+        LocalDateTime endDateTime = getEndDateTime(endDate);
+
+        List<GetSpendingDto> spendingList =
+            spendingRepository.findByDateBetweenOrderByDateDesc(startDateTime, endDateTime, category, minAmount, maxAmount, user).stream()
+                .map(GetSpendingDto::from)
+                .toList();
+
+        // 카테고리 목록을 조회하여 카테고리명=금액 map 을 만든다.
+        // -> 0원 쓴 카테고리도 조회 결과로 보여주기 위해서.
+        Map<String, Long> map = new HashMap<>();
+        List<GetCategoryDto> categoryList = categoryService.getCategoryList();
+        for (GetCategoryDto categoryDto : categoryList) {
+            map.put(categoryDto.getName(), 0L);
+        }
+
+        long spendingTotal = 0;
+        for (GetSpendingDto spending : spendingList) {
+            if (spending.getExcludeTotal() == YnColumn.Y) {
+                continue;
+            }
+
+            spendingTotal += spending.getAmount();  // 지출 합계
+            map.replace(spending.getCategoryName(), map.get(spending.getCategoryName()) + spending.getAmount());  // 카테고리별 지출합계
+        }
+
+        // map to List<GetSpendingSummaryDto>
+        List<GetSpendingSummaryDto> spendingTotalByCategory = new ArrayList<>();
+        for (Entry<String, Long> entry : map.entrySet()) {
+            spendingTotalByCategory.add(GetSpendingSummaryDto.of(entry.getKey(), entry.getValue()));
+        }
+
+        return GetSpendingListDto.of(spendingTotal, spendingTotalByCategory, ListResponseDto.from(spendingList));
+    }
+
+    // 쿼리로 모든 응답 값들을 조회
+    @Transactional(readOnly = true)
+    public List<GetSpendingDto> getSpendingListWithQuery(
         LocalDate startDate,
         LocalDate endDate,
         List<String> category,
@@ -96,7 +151,8 @@ public class SpendingService {
 
         int categorySize = (category != null) ? category.size() : 0;
 
-        return spendingRepository.getSumOfAmountByCategory(startDateTime, endDateTime, categorySize, category, minAmount, maxAmount, user.getId()).stream()
+        return spendingRepository.getSumOfAmountByCategory(startDateTime, endDateTime, categorySize, category, minAmount, maxAmount, user.getId())
+            .stream()
             .map(projection -> GetSpendingSummaryDto.of(projection.getCategoryName(), projection.getAmount()))
             .toList();
     }

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -130,9 +130,6 @@ public class SpendingService {
             spendingRepository.getUsedAmountByCategory(getStartDateTime(firstDayOfMonth), getEndDateTime(today), user.getId());
         // 카테고리별로 순회하며 지출 추천
         for (SpendingRecommendProjection projection : usedAmountByCategory) {
-            System.out.println("===========(" + projection.getCategoryName() + ")============================================================");
-            System.out.println(" @#$%^&%$##$^%#^%$@^&*%$*#= " + projection.getCategoryName() + " = " + projection.getUsedAmount());
-
             // 2. 카테고리의 이번 달 예산 조회
             Long totalBudgetOfMonth = budgetRepository.findAmountByUserAndCategory(firstDayOfMonth, user, projection.getCategoryName());
 
@@ -147,14 +144,6 @@ public class SpendingService {
 
             recommendSpendingByCategory.add(spendingRecommendByCategory);
             recommendSpendingTotal += spendingRecommendByCategory.getRecommendAmount();
-        }
-
-        List<SpendingTodayProjection> todaySpendingByCategory =
-            spendingRepository.getSumAmountByCategoryAndDate(getStartDateTime(firstDayOfMonth), getEndDateTime(today), user);
-        for (SpendingTodayProjection projection : todaySpendingByCategory) {
-
-            System.out.println("===========(" + projection.getCategory().getName() + ")============================================================");
-            System.out.println(" @#$%^&%$##$^%#^%$@^&*%$*#= " + projection.getCategory().getId() + " = " + projection.getUsedAmount());
         }
 
         return GetSpendingRecommendDto.of(recommendSpendingTotal, recommendSpendingByCategory);

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/SpendingService.java
@@ -32,13 +32,8 @@ public class SpendingService {
         User user = userService.getUser(loginId);
         Category category = categoryService.getCategory(categoryName);
 
-        Spending spending = createSpending(date, amount, memo, excludeTotal, user, category);
+        Spending spending = spendingRepository.save(Spending.createSpending(date, amount, memo, excludeTotal, user, category));
         return spending.getId();
-    }
-
-    private Spending createSpending(LocalDateTime date, long amount, String memo, boolean excludeTotal, User user, Category category) {
-        Spending createdSpending = Spending.createSpending(date, amount, memo, excludeTotal, user, category);
-        return spendingRepository.save(createdSpending);
     }
 
     @Transactional

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingListDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingListDto.java
@@ -1,0 +1,22 @@
+package com.wealdy.saemsembackend.domain.spending.service.dto;
+
+import com.wealdy.saemsembackend.domain.core.response.ListResponseDto;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class GetSpendingListDto {
+
+    private final long spendingTotal;
+    private final List<GetSpendingSummaryDto> spendingTotalByCategory;
+    private final ListResponseDto<GetSpendingDto> spendingList;
+
+    public static GetSpendingListDto of(
+        long spendingTotal, List<GetSpendingSummaryDto> spendingTotalByCategory, ListResponseDto<GetSpendingDto> spendingList
+    ) {
+        return new GetSpendingListDto(spendingTotal, spendingTotalByCategory, spendingList);
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingRecommendByCategoryDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingRecommendByCategoryDto.java
@@ -1,0 +1,18 @@
+package com.wealdy.saemsembackend.domain.spending.service.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class GetSpendingRecommendByCategoryDto {
+
+    private final String categoryName;
+    private final long recommendAmount;
+    private String message;
+
+    public static GetSpendingRecommendByCategoryDto of(String categoryName, long recommendAmount, String message) {
+        return new GetSpendingRecommendByCategoryDto(categoryName, recommendAmount, message);
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingRecommendDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingRecommendDto.java
@@ -1,0 +1,18 @@
+package com.wealdy.saemsembackend.domain.spending.service.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class GetSpendingRecommendDto {
+
+    private final long recommendSpendingTotal;
+    private final List<GetSpendingRecommendByCategoryDto> recommendSpendingByCategory;
+
+    public static GetSpendingRecommendDto of(long recommendSpendingTotal, List<GetSpendingRecommendByCategoryDto> recommendSpendingByCategory) {
+        return new GetSpendingRecommendDto(recommendSpendingTotal, recommendSpendingByCategory);
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingTodayByCategoryDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingTodayByCategoryDto.java
@@ -1,0 +1,19 @@
+package com.wealdy.saemsembackend.domain.spending.service.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class GetSpendingTodayByCategoryDto {
+
+    private final String categoryName;
+    private final long moderateAmount;
+    private final long todayUsedAmount;
+    private String riskRate;
+
+    public static GetSpendingTodayByCategoryDto of(String categoryName, long moderateAmount, long todayUsedAmount, String riskRate) {
+        return new GetSpendingTodayByCategoryDto(categoryName, moderateAmount, todayUsedAmount, riskRate);
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingTodayDto.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/spending/service/dto/GetSpendingTodayDto.java
@@ -1,0 +1,18 @@
+package com.wealdy.saemsembackend.domain.spending.service.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class GetSpendingTodayDto {
+
+    private final long todaySpendingTotal;
+    private final List<GetSpendingTodayByCategoryDto> todaySpendingTotalByCategory;
+
+    public static GetSpendingTodayDto of(long todaySpendingTotal, List<GetSpendingTodayByCategoryDto> todaySpendingTotalByCategory) {
+        return new GetSpendingTodayDto(todaySpendingTotal, todaySpendingTotalByCategory);
+    }
+}

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/repository/JpaUserRepository.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/repository/JpaUserRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class CustomUserRepository implements UserRepository {
+public class JpaUserRepository implements UserRepository {
 
     private final EntityManager em;
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
@@ -48,7 +48,7 @@ public class UserService {
     public GetLoginDto login(String loginId, String password) {
         User user = userRepository.findByLoginId(loginId)
             .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND_LOGIN_ID));
-        if (!(password).equals(user.getPassword())) {
+        if (!password.equals(user.getPassword())) {
             throw new NotFoundException(ResponseCode.NOT_FOUND_PASSWORD);
         }
 

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.wealdy.saemsembackend.domain.user.service;
 import static com.wealdy.saemsembackend.domain.core.response.ResponseCode.NOT_FOUND_USER;
 
 import com.wealdy.saemsembackend.domain.core.exception.AlreadyExistException;
+import com.wealdy.saemsembackend.domain.core.exception.InvalidUserException;
 import com.wealdy.saemsembackend.domain.core.exception.NotFoundException;
 import com.wealdy.saemsembackend.domain.core.response.ResponseCode;
 import com.wealdy.saemsembackend.domain.core.util.JwtUtil;
@@ -47,9 +48,9 @@ public class UserService {
     @Transactional
     public GetLoginDto login(String loginId, String password) {
         User user = userRepository.findByLoginId(loginId)
-            .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND_LOGIN_ID));
+            .orElseThrow(() -> new InvalidUserException(ResponseCode.INVALID_LOGIN_ID));
         if (!password.equals(user.getPassword())) {
-            throw new NotFoundException(ResponseCode.NOT_FOUND_PASSWORD);
+            throw new InvalidUserException(ResponseCode.INVALID_PASSWORD);
         }
 
         JwtUtil jwtUtil = JwtUtil.getInstance();

--- a/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
+++ b/src/main/java/com/wealdy/saemsembackend/domain/user/service/UserService.java
@@ -20,6 +20,7 @@ public class UserService {
 
     private final UserRepository userRepository;
 
+    // 회원 가입
     @Transactional
     public void join(String loginId, String password, String nickname) {
         validateDuplicateId(loginId);
@@ -28,23 +29,27 @@ public class UserService {
         createUser(loginId, password, nickname);
     }
 
+    // 로그인 ID 중복 확인
     private void validateDuplicateId(String loginId) {
         if (userRepository.findByLoginId(loginId).isPresent()) {
             throw new AlreadyExistException(ResponseCode.ALREADY_EXIST_ID);
         }
     }
 
+    // 닉네임 중복 확인
     private void validateDuplicateNickname(String nickname) {
         if (userRepository.findByNickname(nickname).isPresent()) {
             throw new AlreadyExistException(ResponseCode.ALREADY_EXIST_NICKNAME);
         }
     }
 
+    // user 생성
     private void createUser(String loginId, String password, String nickname) {
         User newUser = User.createUser(loginId, password, nickname);
         userRepository.save(newUser);
     }
 
+    // 로그인
     @Transactional
     public GetLoginDto login(String loginId, String password) {
         User user = userRepository.findByLoginId(loginId)
@@ -58,6 +63,7 @@ public class UserService {
         return new GetLoginDto(accessToken);
     }
 
+    // 로그인 ID 로 user 조회
     @Transactional(readOnly = true)
     public User getUser(String loginId) {
         return userRepository.findByLoginId(loginId)

--- a/src/test/java/com/wealdy/saemsembackend/domain/budget/entity/BudgetTest.java
+++ b/src/test/java/com/wealdy/saemsembackend/domain/budget/entity/BudgetTest.java
@@ -1,0 +1,83 @@
+package com.wealdy.saemsembackend.domain.budget.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wealdy.saemsembackend.domain.category.entity.Category;
+import com.wealdy.saemsembackend.domain.core.enums.YnColumn;
+import com.wealdy.saemsembackend.domain.core.util.DateUtils;
+import com.wealdy.saemsembackend.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BudgetTest {
+
+    @DisplayName("[createBudget] 지출 생성에 성공한다.")
+    @Test
+    void createBudget() {
+        // given
+        User user = new User(1L, "loginId", "1234", "nickname", YnColumn.N, null);
+        Category category = Category.of(1L, "기타");
+
+        // when
+        Budget budget = Budget.createBudget(
+            DateUtils.convertFirstDayOfMonth(2024, 1),
+            100000,
+            user,
+            category
+        );
+
+        // then
+        assertThat(budget.getDate()).isEqualTo(DateUtils.convertFirstDayOfMonth(2024, 1));
+        assertThat(budget.getAmount()).isEqualTo(100000);
+        assertThat(budget.getUser()).isEqualTo(user);
+        assertThat(budget.getCategory()).isEqualTo(category);
+    }
+
+    @DisplayName("[of] id 포함 지출 생성에 성공한다.")
+    @Test
+    void of() {
+        // given
+        User user = new User(1L, "loginId", "1234", "nickname", YnColumn.N, null);
+        Category category = Category.of(1L, "기타");
+
+        // when
+        Budget budget = Budget.of(
+            1L,
+            DateUtils.convertFirstDayOfMonth(2024, 1),
+            100000,
+            user,
+            category
+        );
+
+        // then
+        assertThat(budget.getId()).isEqualTo(1L);
+        assertThat(budget.getDate()).isEqualTo(DateUtils.convertFirstDayOfMonth(2024, 1));
+        assertThat(budget.getAmount()).isEqualTo(100000);
+        assertThat(budget.getUser()).isEqualTo(user);
+        assertThat(budget.getCategory()).isEqualTo(category);
+    }
+
+    @DisplayName("[updateBudget] 지출 금액 수정에 성공한다.")
+    @Test
+    void updateBudget() {
+        // given
+        User user = new User(1L, "loginId", "1234", "nickname", YnColumn.N, null);
+        Category category = Category.of(1L, "기타");
+
+        Budget budget = Budget.createBudget(
+            DateUtils.convertFirstDayOfMonth(2024, 1),
+            100000,
+            user,
+            category
+        );
+
+        // when
+        budget.updateBudget(200000);
+
+        // then
+        assertThat(budget.getDate()).isEqualTo(DateUtils.convertFirstDayOfMonth(2024, 1));
+        assertThat(budget.getAmount()).isEqualTo(200000);
+        assertThat(budget.getUser()).isEqualTo(user);
+        assertThat(budget.getCategory()).isEqualTo(category);
+    }
+}

--- a/src/test/java/com/wealdy/saemsembackend/domain/budget/mock/MockBudgetRepository.java
+++ b/src/test/java/com/wealdy/saemsembackend/domain/budget/mock/MockBudgetRepository.java
@@ -1,0 +1,79 @@
+package com.wealdy.saemsembackend.domain.budget.mock;
+
+import com.wealdy.saemsembackend.domain.budget.entity.Budget;
+import com.wealdy.saemsembackend.domain.budget.repository.BudgetRepository;
+import com.wealdy.saemsembackend.domain.budget.repository.projection.BudgetRecommendProjection;
+import com.wealdy.saemsembackend.domain.budget.repository.projection.BudgetSummaryProjection;
+import com.wealdy.saemsembackend.domain.budget.repository.projection.BudgetTotalProjection;
+import com.wealdy.saemsembackend.domain.category.entity.Category;
+import com.wealdy.saemsembackend.domain.user.entity.User;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class MockBudgetRepository implements BudgetRepository {
+
+    private final List<Budget> budgetList = new ArrayList<>();
+    private final List<BudgetSummaryProjection> budgetSummaryProjection = new ArrayList<>();
+
+    @Override
+    public Budget save(Budget budget) {
+        budgetList.removeIf(removeBudget -> {
+            return removeBudget.getId().equals(budget.getId());
+        });
+        budgetList.add(budget);
+        return budget;
+    }
+
+    @Override
+    public Optional<Budget> findByDateAndCategoryAndUser(LocalDate date, Category category, User user) {
+        return budgetList.stream()
+            .filter(budget -> budget.getDate().equals(date))
+            .filter(budget -> budget.getCategory().equals(category))
+            .filter(budget -> budget.getUser().equals(user))
+            .findFirst();
+    }
+
+    @Override
+    public List<BudgetSummaryProjection> findByDateAndUser(LocalDate date, User user) {
+        budgetSummaryProjection.clear();
+        budgetSummaryProjection.add(
+            new BudgetSummaryProjection() {
+                @Override
+                public String getCategoryName() {
+                    return "기타";
+                }
+
+                @Override
+                public Long getAmount() {
+                    return 100000L;
+                }
+            }
+        );
+        budgetSummaryProjection.add(
+            new BudgetSummaryProjection() {
+                @Override
+                public String getCategoryName() {
+                    return "식비";
+                }
+
+                @Override
+                public Long getAmount() {
+                    return 333333L;
+                }
+            }
+        );
+        return budgetSummaryProjection;
+    }
+
+    @Override
+    public List<BudgetRecommendProjection> findByDate(LocalDate date) {
+        return null;
+    }
+
+    @Override
+    public List<BudgetTotalProjection> sumByUser(LocalDate date) {
+        return null;
+    }
+}

--- a/src/test/java/com/wealdy/saemsembackend/domain/budget/mock/MockBudgetRepository.java
+++ b/src/test/java/com/wealdy/saemsembackend/domain/budget/mock/MockBudgetRepository.java
@@ -76,4 +76,9 @@ public class MockBudgetRepository implements BudgetRepository {
     public List<BudgetTotalProjection> sumByUser(LocalDate date) {
         return null;
     }
+
+    @Override
+    public Long findAmountByUserAndCategory(LocalDate date, User user, String categoryId) {
+        return null;
+    }
 }

--- a/src/test/java/com/wealdy/saemsembackend/domain/budget/service/BudgetServiceTest.java
+++ b/src/test/java/com/wealdy/saemsembackend/domain/budget/service/BudgetServiceTest.java
@@ -1,0 +1,170 @@
+package com.wealdy.saemsembackend.domain.budget.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wealdy.saemsembackend.domain.budget.entity.Budget;
+import com.wealdy.saemsembackend.domain.budget.mock.MockBudgetRepository;
+import com.wealdy.saemsembackend.domain.budget.repository.BudgetRepository;
+import com.wealdy.saemsembackend.domain.budget.service.dto.BudgetSummaryDto;
+import com.wealdy.saemsembackend.domain.budget.service.dto.GetBudgetDto;
+import com.wealdy.saemsembackend.domain.category.entity.Category;
+import com.wealdy.saemsembackend.domain.category.mock.MockCategoryRepository;
+import com.wealdy.saemsembackend.domain.category.repository.CategoryRepository;
+import com.wealdy.saemsembackend.domain.category.service.CategoryService;
+import com.wealdy.saemsembackend.domain.core.enums.YnColumn;
+import com.wealdy.saemsembackend.domain.core.util.DateUtils;
+import com.wealdy.saemsembackend.domain.user.entity.User;
+import com.wealdy.saemsembackend.domain.user.mock.MockUserRepository;
+import com.wealdy.saemsembackend.domain.user.repository.UserRepository;
+import com.wealdy.saemsembackend.domain.user.service.UserService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BudgetServiceTest {
+
+    BudgetRepository budgetRepository;
+    BudgetService budgetService;
+    CategoryService categoryService;
+    CategoryRepository categoryRepository;
+    UserService userService;
+    UserRepository userRepository;
+
+
+    @BeforeEach
+    void init() {
+        categoryRepository = new MockCategoryRepository();
+        categoryService = new CategoryService(categoryRepository);
+
+        userRepository = new MockUserRepository();
+        userService = new UserService(userRepository);
+
+        budgetRepository = new MockBudgetRepository();
+        budgetService = new BudgetService(budgetRepository, categoryService, userService);
+    }
+
+    @DisplayName("[getBudgetList] 예산 목록 조회에 성공한다.")
+    @Test
+    void getBudgetList() {
+        // given
+        User user = new User(1L, "loginId", "1234", "nickname", YnColumn.N, null);
+        userRepository.save(user);
+
+        Category category1 = Category.of(1L, "기타");
+        categoryRepository.save(category1);
+
+        Category category2 = Category.of(2L, "식비");
+        categoryRepository.save(category2);
+
+        Budget budget = Budget.of(1L, DateUtils.convertFirstDayOfMonth(2024, 1), 100000, user, category1);
+        budgetRepository.save(budget);
+
+        Budget budget2 = Budget.of(2L, DateUtils.convertFirstDayOfMonth(2024, 1), 333333, user, category2);
+        budgetRepository.save(budget2);
+
+        // when
+        List<GetBudgetDto> budgetList = budgetService.getBudgetList(DateUtils.convertFirstDayOfMonth(2024, 1), "loginId");
+
+        // then
+        assertThat(budgetList.size()).isEqualTo(2);
+        assertThat(budgetList.get(0).getCategoryName()).isEqualTo("기타");
+        assertThat(budgetList.get(1).getCategoryName()).isEqualTo("식비");
+        assertThat(budgetList.get(0).getAmount()).isEqualTo(100000);
+        assertThat(budgetList.get(1).getAmount()).isEqualTo(333333);
+    }
+
+    @DisplayName("[createBudget] 예산 추가에 성공한다.")
+    @Test
+    void createBudget() {
+        // given
+        User user = new User(1L, "loginId", "1234", "nickname", YnColumn.N, null);
+        userRepository.save(user);
+
+        Category category = Category.of(1L, "기타");
+        categoryRepository.save(category);
+
+        List<BudgetSummaryDto> budgetSummaryDtoList = new ArrayList<>();
+        budgetSummaryDtoList.add(
+            new BudgetSummaryDto() {
+                @Override
+                public String getCategoryName() {
+                    return "기타";
+                }
+
+                @Override
+                public long getAmount() {
+                    return 200000;
+                }
+            }
+        );
+
+        // when
+        budgetService.createBudget(DateUtils.convertFirstDayOfMonth(2024, 1), budgetSummaryDtoList, user.getLoginId());
+        Optional<Budget> budget = budgetRepository.findByDateAndCategoryAndUser(
+            DateUtils.convertFirstDayOfMonth(2024, 1), category, user);
+
+        // then
+        assertThat(budget.isPresent()).isTrue();
+        assertThat(budget.get().getDate()).isEqualTo(DateUtils.convertFirstDayOfMonth(2024, 1));
+        assertThat(budget.get().getAmount()).isEqualTo(200000);
+        assertThat(budget.get().getUser()).isEqualTo(user);
+        assertThat(budget.get().getCategory()).isEqualTo(category);
+    }
+
+    @DisplayName("[updateBudget] 이미 존재하는 예산은 금액만 수정 된다.")
+    @Test
+    void updateBudget() {
+        // given
+        User user = new User(1L, "loginId", "1234", "nickname", YnColumn.N, null);
+        userRepository.save(user);
+
+        Category category = Category.of(1L, "기타");
+        categoryRepository.save(category);
+
+        List<BudgetSummaryDto> budgetSummaryDtoList = new ArrayList<>();
+        budgetSummaryDtoList.add(
+            new BudgetSummaryDto() {
+                @Override
+                public String getCategoryName() {
+                    return "기타";
+                }
+
+                @Override
+                public long getAmount() {
+                    return 200000;
+                }
+            }
+        );
+        budgetService.createBudget(DateUtils.convertFirstDayOfMonth(2024, 1), budgetSummaryDtoList, user.getLoginId());
+
+        // when
+        List<BudgetSummaryDto> budgetSummaryDtoList2 = new ArrayList<>();
+        budgetSummaryDtoList2.add(
+            new BudgetSummaryDto() {
+                @Override
+                public String getCategoryName() {
+                    return "기타";
+                }
+
+                @Override
+                public long getAmount() {
+                    return 400000;
+                }
+            }
+        );
+        budgetService.createBudget(DateUtils.convertFirstDayOfMonth(2024, 1), budgetSummaryDtoList2, user.getLoginId());
+
+        Optional<Budget> budget = budgetRepository.findByDateAndCategoryAndUser(
+            DateUtils.convertFirstDayOfMonth(2024, 1), category, user);
+
+        // then
+        assertThat(budget.isPresent()).isTrue();
+        assertThat(budget.get().getDate()).isEqualTo(DateUtils.convertFirstDayOfMonth(2024, 1));
+        assertThat(budget.get().getAmount()).isEqualTo(400000);
+        assertThat(budget.get().getUser()).isEqualTo(user);
+        assertThat(budget.get().getCategory()).isEqualTo(category);
+    }
+}

--- a/src/test/java/com/wealdy/saemsembackend/domain/category/mock/MockCategoryRepository.java
+++ b/src/test/java/com/wealdy/saemsembackend/domain/category/mock/MockCategoryRepository.java
@@ -1,0 +1,29 @@
+package com.wealdy.saemsembackend.domain.category.mock;
+
+import com.wealdy.saemsembackend.domain.category.entity.Category;
+import com.wealdy.saemsembackend.domain.category.repository.CategoryRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class MockCategoryRepository implements CategoryRepository {
+
+    private final List<Category> categoryList = new ArrayList<>();
+
+    public void save(Category category) {
+        categoryList.removeIf(removeCategory -> removeCategory.getId().equals(category.getId()));
+        categoryList.add(category);
+    }
+
+    @Override
+    public List<Category> findAll() {
+        return categoryList;
+    }
+
+    @Override
+    public Optional<Category> findByName(String name) {
+        return categoryList.stream()
+            .filter(category -> category.getName().equals(name))
+            .findFirst();
+    }
+}

--- a/src/test/java/com/wealdy/saemsembackend/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/wealdy/saemsembackend/domain/category/service/CategoryServiceTest.java
@@ -1,0 +1,152 @@
+package com.wealdy.saemsembackend.domain.category.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+import com.wealdy.saemsembackend.domain.category.entity.Category;
+import com.wealdy.saemsembackend.domain.category.mock.MockCategoryRepository;
+import com.wealdy.saemsembackend.domain.category.repository.CategoryRepository;
+import com.wealdy.saemsembackend.domain.category.service.dto.GetCategoryDto;
+import com.wealdy.saemsembackend.domain.core.exception.NotFoundException;
+import com.wealdy.saemsembackend.domain.core.response.ResponseCode;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CategoryServiceTest {
+
+    CategoryRepository categoryRepository;
+    CategoryService categoryService;
+
+
+    @BeforeEach
+    void init() {
+        categoryRepository = new MockCategoryRepository();
+        categoryService = new CategoryService(categoryRepository);
+    }
+
+
+    @DisplayName("[getCategoryList] 카테고리 목록 조회를 성공한다.")
+    @Test
+    void getCategoryList() {
+        // given
+        categoryRepository.save(
+            new Category() {
+                @Override
+                public Long getId() {
+                    return 1L;
+                }
+
+                @Override
+                public String getName() {
+                    return "기타";
+                }
+            }
+        );
+        categoryRepository.save(
+            new Category() {
+                @Override
+                public Long getId() {
+                    return 2L;
+                }
+
+                @Override
+                public String getName() {
+                    return "식비";
+                }
+            }
+        );
+        categoryRepository.save(
+            new Category() {
+                @Override
+                public Long getId() {
+                    return 3L;
+                }
+
+                @Override
+                public String getName() {
+                    return "교통비";
+                }
+            }
+        );
+
+        // when
+        List<GetCategoryDto> categoryList = categoryService.getCategoryList();
+
+        // then
+        assertThat(categoryList.size()).isEqualTo(3);
+        assertThat(categoryList.get(0).getName()).isEqualTo("기타");
+        assertThat(categoryList.get(1).getName()).isEqualTo("식비");
+        assertThat(categoryList.get(2).getName()).isEqualTo("교통비");
+    }
+
+    @DisplayName("[getCategory] 카테고리 name 으로 조회를 성공한다.")
+    @Test
+    void getCategory() {
+        // given
+        categoryRepository.save(
+            new Category() {
+                @Override
+                public Long getId() {
+                    return 1L;
+                }
+
+                @Override
+                public String getName() {
+                    return "기타";
+                }
+            }
+        );
+        categoryRepository.save(
+            new Category() {
+                @Override
+                public Long getId() {
+                    return 2L;
+                }
+
+                @Override
+                public String getName() {
+                    return "식비";
+                }
+            }
+        );
+        categoryRepository.save(
+            new Category() {
+                @Override
+                public Long getId() {
+                    return 3L;
+                }
+
+                @Override
+                public String getName() {
+                    return "교통비";
+                }
+            }
+        );
+
+        // when
+        Category category1 = categoryService.getCategory("기타");
+        Category category2 = categoryService.getCategory("식비");
+        Category category3 = categoryService.getCategory("교통비");
+
+        // then
+        assertThat(category1.getName()).isEqualTo("기타");
+        assertThat(category2.getName()).isEqualTo("식비");
+        assertThat(category3.getName()).isEqualTo("교통비");
+    }
+
+    @DisplayName("[getCategoryFailedWithNoName] 없는 name 으로 카테고리 조회시 (NotFoundException) 발생한다.")
+    @Test
+    void getCategoryFailedWithNoName() {
+        // given
+        // when
+        NotFoundException notFoundException = catchThrowableOfType(
+            () -> categoryService.getCategory("기타"),
+            NotFoundException.class
+        );
+
+        // then
+        assertThat(notFoundException.getMessage()).isEqualTo(ResponseCode.NOT_FOUND_CATEGORY.getMessage());
+    }
+}

--- a/src/test/java/com/wealdy/saemsembackend/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/wealdy/saemsembackend/domain/category/service/CategoryServiceTest.java
@@ -31,45 +31,9 @@ class CategoryServiceTest {
     @Test
     void getCategoryList() {
         // given
-        categoryRepository.save(
-            new Category() {
-                @Override
-                public Long getId() {
-                    return 1L;
-                }
-
-                @Override
-                public String getName() {
-                    return "기타";
-                }
-            }
-        );
-        categoryRepository.save(
-            new Category() {
-                @Override
-                public Long getId() {
-                    return 2L;
-                }
-
-                @Override
-                public String getName() {
-                    return "식비";
-                }
-            }
-        );
-        categoryRepository.save(
-            new Category() {
-                @Override
-                public Long getId() {
-                    return 3L;
-                }
-
-                @Override
-                public String getName() {
-                    return "교통비";
-                }
-            }
-        );
+        categoryRepository.save(Category.of(1L, "기타"));
+        categoryRepository.save(Category.of(2L, "식비"));
+        categoryRepository.save(Category.of(3L, "교통비"));
 
         // when
         List<GetCategoryDto> categoryList = categoryService.getCategoryList();
@@ -85,45 +49,9 @@ class CategoryServiceTest {
     @Test
     void getCategory() {
         // given
-        categoryRepository.save(
-            new Category() {
-                @Override
-                public Long getId() {
-                    return 1L;
-                }
-
-                @Override
-                public String getName() {
-                    return "기타";
-                }
-            }
-        );
-        categoryRepository.save(
-            new Category() {
-                @Override
-                public Long getId() {
-                    return 2L;
-                }
-
-                @Override
-                public String getName() {
-                    return "식비";
-                }
-            }
-        );
-        categoryRepository.save(
-            new Category() {
-                @Override
-                public Long getId() {
-                    return 3L;
-                }
-
-                @Override
-                public String getName() {
-                    return "교통비";
-                }
-            }
-        );
+        categoryRepository.save(Category.of(1L, "기타"));
+        categoryRepository.save(Category.of(2L, "식비"));
+        categoryRepository.save(Category.of(3L, "교통비"));
 
         // when
         Category category1 = categoryService.getCategory("기타");

--- a/src/test/java/com/wealdy/saemsembackend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/wealdy/saemsembackend/domain/user/service/UserServiceTest.java
@@ -45,9 +45,9 @@ class UserServiceTest {
         assertThat(joinUser.get().getNickname()).isEqualTo("nickname");
     }
 
-    @DisplayName("[validateDuplicateId] 이미 존재하는 아이디로 회원가입한다.")
+    @DisplayName("[joinFailedWithDuplicateId] 이미 존재하는 아이디로 회원가입하면 (AlreadyExistException) 발생한다.")
     @Test
-    void validateDuplicateId() {
+    void joinFailedWithDuplicateId() {
         // given
         User user = new User(1L, "loginId", "1234", "nickname", YnColumn.N, null);
         userRepository.save(user);
@@ -62,9 +62,9 @@ class UserServiceTest {
         assertThat(alreadyExistException.getMessage()).isEqualTo(ResponseCode.ALREADY_EXIST_ID.getMessage());
     }
 
-    @DisplayName("[validateDuplicateNickname] 이미 존재하는 닉네임으로 회원가입한다.")
+    @DisplayName("[joinFailedWithDuplicateNickname] 이미 존재하는 닉네임으로 회원가입하면 (AlreadyExistException) 발생한다.")
     @Test
-    void validateDuplicateNickname() {
+    void joinFailedWithDuplicateNickname() {
         // given
         User user = new User(1L, "loginId", "1234", "nickname", YnColumn.N, null);
         userRepository.save(user);
@@ -95,9 +95,9 @@ class UserServiceTest {
         assertThat(accessToken.split("\\.").length).isEqualTo(3);
     }
 
-    @DisplayName("[loginWithNoId] 없는 아이디로 로그인한다.")
+    @DisplayName("[loginFailedWithNoId] 없는 아이디로 로그인하면 (InvalidUserException) 발생한다.")
     @Test
-    void loginWithNoId() {
+    void loginFailedWithNoId() {
         // given
         User user = new User(1L, "loginId", "1234", "nickname", YnColumn.N, null);
         userRepository.save(user);
@@ -112,9 +112,9 @@ class UserServiceTest {
         assertThat(invalidUserException.getMessage()).isEqualTo(ResponseCode.INVALID_LOGIN_ID.getMessage());
     }
 
-    @DisplayName("[loginWithNoPw] 없는 비밀번호로 로그인한다.")
+    @DisplayName("[loginFailedWithNoPw] 없는 비밀번호로 로그인하면 (InvalidUserException) 발생한다.")
     @Test
-    void loginWithNoPw() {
+    void loginFailedWithNoPw() {
         // given
         User user = new User(1L, "loginId", "1234", "nickname", YnColumn.N, null);
         userRepository.save(user);
@@ -143,9 +143,9 @@ class UserServiceTest {
         assertThat(user.getLoginId()).isEqualTo("loginId");
     }
 
-    @DisplayName("[getUserFail] loginId 로 User 조회를 실패한다.")
+    @DisplayName("[getUserFailedWithNoId] 없는 loginId 로 User 조회시 (NotFoundException) 발생한다.")
     @Test
-    void getUserFail() {
+    void getUserFailedWithNoId() {
         // given
         // when
         NotFoundException notFoundException = Assertions.catchThrowableOfType(

--- a/src/test/java/com/wealdy/saemsembackend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/wealdy/saemsembackend/domain/user/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.wealdy.saemsembackend.domain.core.enums.YnColumn;
 import com.wealdy.saemsembackend.domain.core.exception.AlreadyExistException;
+import com.wealdy.saemsembackend.domain.core.exception.InvalidUserException;
 import com.wealdy.saemsembackend.domain.core.exception.NotFoundException;
 import com.wealdy.saemsembackend.domain.core.response.ResponseCode;
 import com.wealdy.saemsembackend.domain.user.entity.User;
@@ -102,13 +103,13 @@ class UserServiceTest {
         userRepository.save(user);
 
         // when
-        NotFoundException notFoundException = Assertions.catchThrowableOfType(
+        InvalidUserException invalidUserException = Assertions.catchThrowableOfType(
             () -> userService.login("loginId2", "1234"),
-            NotFoundException.class
+            InvalidUserException.class
         );
 
         // then
-        assertThat(notFoundException.getMessage()).isEqualTo(ResponseCode.NOT_FOUND_LOGIN_ID.getMessage());
+        assertThat(invalidUserException.getMessage()).isEqualTo(ResponseCode.INVALID_LOGIN_ID.getMessage());
     }
 
     @DisplayName("[loginWithNoPw] 없는 비밀번호로 로그인한다.")
@@ -119,13 +120,13 @@ class UserServiceTest {
         userRepository.save(user);
 
         // when
-        NotFoundException notFoundException = Assertions.catchThrowableOfType(
+        InvalidUserException invalidUserException = Assertions.catchThrowableOfType(
             () -> userService.login("loginId", "1111"),
-            NotFoundException.class
+            InvalidUserException.class
         );
 
         // then
-        assertThat(notFoundException.getMessage()).isEqualTo(ResponseCode.NOT_FOUND_PASSWORD.getMessage());
+        assertThat(invalidUserException.getMessage()).isEqualTo(ResponseCode.INVALID_PASSWORD.getMessage());
     }
 
     @DisplayName("[getUser] loginId 로 User 조회를 성공한다.")

--- a/src/test/java/com/wealdy/saemsembackend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/wealdy/saemsembackend/domain/user/service/UserServiceTest.java
@@ -147,12 +147,9 @@ class UserServiceTest {
     @Test
     void getUserFail() {
         // given
-        User newUser = new User(1L, "loginId", "1234", "nickname", YnColumn.N, null);
-        userRepository.save(newUser);
-
         // when
         NotFoundException notFoundException = Assertions.catchThrowableOfType(
-            () -> userService.getUser("loginId2"),
+            () -> userService.getUser("loginId"),
             NotFoundException.class
         );
 


### PR DESCRIPTION
## 내용
1. 예산 설계 (추천) API
2. 오늘 지출 추천 API
3. 오늘 지출 안내 API
4. 지출 목록 조회 API  - 쿼리로 조회하는 방식에서 Java 로 처리 로직 구현하도록 변경
5. 코드 리뷰 반영

## 질문
인터페이스에 구현체가 2개 있을 때 한 쪽 구현체에서만 사용하고 싶은 메소드가 있을 때는 어떻게 코드를 작성하나요??

### 질문 나오게된 계기
`BudgetRepository` 의 구현체로  `DefaultBudgetRepository` 와 `MockBudgetRepository` 가 있을 때
 `DefaultBudgetRepository` 에만 구현하고 싶은 메소드(A)가 생겼다.

1. `DefaultBudgetRepository` 에만 넣고 `BudgetRepository` 에 안넣었더니
`service` 에서 가져다 쓸 때 `private final DefaultBudgetRepository budgetRepository;`
이렇게 써야만 A 메소드를 쓸 수 있던데 구현체에 의존하는 것이므로 DIP 위반이라 철수!

2. `BudgetRepository`  에도 A 메소드를 넣으면 `MockBudgetRepository` 에서도  A 메소드를 `@Override` 해야하는데,
구현 할 내용이 없으니 그냥 return null; 해 놓는다.

저는 일단 2번으로 해놓았는데,, 이것도 별로 안좋은 코드 같아서요,, 원래 이럴 땐 어떻게 해야하나요??


## 남은 기능
1. 지출 통계 API
2. 알림 발송 기능
3. 배포